### PR TITLE
fix(epic-13): CORS origin restriction, dev env loading, docker-compose secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,8 @@ JWT_PUBLIC_KEY_PATH=./secrets/jwt_public_key.pem
 #   openssl rand -base64 32 > secrets/salary_encryption_key.txt
 # In production this is injected as a Docker secret mounted at /run/secrets/
 SALARY_ENCRYPTION_KEY=./secrets/salary_encryption_key.txt
+
+# ── CORS ─────────────────────────────────────────────────────────────────
+# Allowed origin for CORS requests.
+# Must match the frontend URL exactly (protocol + host + port).
+CORS_ORIGIN=http://localhost:3000

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"dev": "tsx watch src/index.ts",
+		"dev": "tsx watch --env-file=.env src/index.ts",
 		"build": "tsc",
 		"lint": "eslint src",
 		"typecheck": "tsc --noEmit",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -27,7 +27,10 @@ export async function buildApp() {
 
 	await app.register(logging);
 	await app.register(metrics);
-	await app.register(cors);
+	await app.register(cors, {
+		origin: process.env.CORS_ORIGIN || 'http://localhost:3000',
+		credentials: true,
+	});
 	await app.register(cookie);
 	await app.register(rateLimit, {
 		max: 100,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,8 +21,16 @@ services:
       NODE_ENV: development
       DATABASE_URL: postgresql://app_user:${DB_PASSWORD:-changeme}@db:5432/budfindb
       LOG_LEVEL: debug
+      JWT_PRIVATE_KEY_PATH: /run/secrets/jwt_private_key
+      JWT_PUBLIC_KEY_PATH: /run/secrets/jwt_public_key
+      SALARY_ENCRYPTION_KEY: /run/secrets/salary_encryption_key
+      CORS_ORIGIN: http://localhost:3000
     ports:
       - '3001:3001'
+    secrets:
+      - jwt_private_key
+      - jwt_public_key
+      - salary_encryption_key
     depends_on:
       db:
         condition: service_healthy
@@ -43,6 +51,14 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+secrets:
+  jwt_private_key:
+    file: ./secrets/jwt_private_key.pem
+  jwt_public_key:
+    file: ./secrets/jwt_public_key.pem
+  salary_encryption_key:
+    file: ./secrets/salary_encryption_key.txt
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary

Resolves post-ship issues found in Epic 13 (Infrastructure) — closes #2.

- **CORS single-origin**: Replaced open `cors` registration with `origin: process.env.CORS_ORIGIN || 'http://localhost:3000'` and `credentials: true`.
- **Dev script .env loading**: Added `--env-file=.env` to the `tsx watch` dev script — Node 22 natively loads env vars.
- **docker-compose.dev.yml**: Added missing `JWT_PRIVATE_KEY_PATH`, `JWT_PUBLIC_KEY_PATH`, `SALARY_ENCRYPTION_KEY`, `CORS_ORIGIN` env vars and `secrets` block with file references.
- **`.env.example`**: Added `CORS_ORIGIN` with documentation.

### Files changed (4)
- `apps/api/src/index.ts`: CORS config
- `apps/api/package.json`: dev script
- `docker-compose.dev.yml`: env vars + secrets
- `.env.example`: CORS_ORIGIN

## Test plan

- [x] All 366 API tests pass (`pnpm --filter @budfin/api test`)
- [x] Typecheck passes
- [ ] Manual: verify `Access-Control-Allow-Origin` header returns configured origin, not `*`
- [ ] Manual: `pnpm --filter @budfin/api dev` loads DATABASE_URL and JWT vars from .env

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>