### PR TITLE
fix(epic-10): planning nav visibility, scenario state consistency

### DIFF
--- a/apps/web/src/components/context-bar.tsx
+++ b/apps/web/src/components/context-bar.tsx
@@ -189,14 +189,9 @@ export function ContextBar() {
 					Scenario
 				</label>
 				<Select
-					value={scenarioId !== null ? String(scenarioId) : 'BASE'}
-					onValueChange={(_value) => {
-						// Stub: scenario is a UI-only control in v1 — no backend for scenario IDs yet.
-						// The setScenario setter is wired and ready; the SCENARIOS list above uses
-						// string keys (BASE / OPTIMISTIC / PESSIMISTIC) rather than numeric IDs.
-						// When the backend ships scenario endpoints, replace this with:
-						//   setScenario(Number(_value))
-						void setScenario;
+					value={scenarioId ?? 'BASE'}
+					onValueChange={(value) => {
+						setScenario(value);
 					}}
 				>
 					<SelectTrigger

--- a/apps/web/src/components/versions/compare-dialog.tsx
+++ b/apps/web/src/components/versions/compare-dialog.tsx
@@ -61,7 +61,6 @@ function CompareDialogContent({ fiscalYear, onClose }: Omit<CompareDialogProps, 
 			version: primaryId,
 			compare: comparisonId,
 			period: 'FULL',
-			scenario: 'BASE',
 		});
 		navigate(`/planning?${params.toString()}`);
 		onClose();

--- a/apps/web/src/hooks/use-workspace-context.ts
+++ b/apps/web/src/hooks/use-workspace-context.ts
@@ -7,7 +7,7 @@ export interface WorkspaceContext {
 	versionId: number | null;
 	comparisonVersionId: number | null;
 	academicPeriod: string | null;
-	scenarioId: number | null;
+	scenarioId: string | null;
 }
 
 export function useWorkspaceContext() {
@@ -20,7 +20,7 @@ export function useWorkspaceContext() {
 		? Number(searchParams.get('compare'))
 		: null;
 	const academicPeriod = searchParams.get('period');
-	const scenarioId = searchParams.get('scenario') ? Number(searchParams.get('scenario')) : null;
+	const scenarioId = searchParams.get('scenario') ?? null;
 
 	const setVersion = useCallback(
 		(id: number | null) => {
@@ -81,11 +81,11 @@ export function useWorkspaceContext() {
 	);
 
 	const setScenario = useCallback(
-		(id: number | null) => {
+		(id: string | null) => {
 			setSearchParams((prev) => {
 				const next = new URLSearchParams(prev);
 				if (id !== null) {
-					next.set('scenario', String(id));
+					next.set('scenario', id);
 				} else {
 					next.delete('scenario');
 				}

--- a/apps/web/src/layouts/management-shell.tsx
+++ b/apps/web/src/layouts/management-shell.tsx
@@ -13,7 +13,6 @@ const navGroups = [
 	},
 	{
 		label: 'Planning',
-		adminOnly: true,
 		items: [
 			{ to: '/versions', label: 'Version Management' },
 			{ to: '/fiscal-periods', label: 'Fiscal Periods' },


### PR DESCRIPTION
## Summary

Fixes two findings from code review (Epic 10 — Version & Scenario):

- **Finding 2 (High):** Planning nav group no longer hidden from non-Admin roles. Removed `adminOnly: true` so BudgetOwner, Editor, and Viewer can access Version Management and Fiscal Periods (matches RBAC matrix AC-18).
- **Finding 5 (Medium):** Fixed broken scenario state across 3 files — removed non-functional `scenario=BASE` from compare URL params, changed `scenarioId` type from `number|null` to `string|null` (prevents NaN from `Number('BASE')`), and wired the scenario dropdown's `onValueChange` to actually call `setScenario`.

Relates to #14

## Changes

| File | Change |
|------|--------|
| `apps/web/src/layouts/management-shell.tsx` | Remove `adminOnly: true` from Planning nav group |
| `apps/web/src/components/versions/compare-dialog.tsx` | Remove `scenario: 'BASE'` from URL params |
| `apps/web/src/hooks/use-workspace-context.ts` | `scenarioId: string\|null`, string passthrough instead of `Number()` |
| `apps/web/src/components/context-bar.tsx` | Wire `setScenario(value)` instead of no-op |

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — zero errors
- [x] `pnpm test` — 373/373 passing, zero regressions
- [ ] Login as Editor/Viewer — Planning nav group visible
- [ ] Compare dialog does not write `scenario` to URL
- [ ] Scenario dropdown changes update URL with string value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>