### PR TITLE
fix(epic-13): validate system-config values against dataType

### DIFF
--- a/apps/api/src/routes/system-config.test.ts
+++ b/apps/api/src/routes/system-config.test.ts
@@ -153,6 +153,65 @@ describe('PUT /api/v1/system-config', () => {
 		});
 	});
 
+	it('rejects non-numeric value for number-type config', async () => {
+		vi.mocked(prisma.systemConfig.findUnique).mockResolvedValue(mockConfigs[0]!);
+
+		const token = await makeToken();
+		const res = await app.inject({
+			method: 'PUT',
+			url: '/api/v1/system-config',
+			headers: authHeader(token),
+			payload: {
+				updates: [{ key: 'lockout_threshold', value: 'foo' }],
+			},
+		});
+		expect(res.statusCode).toBe(400);
+		expect(res.json().error).toContain('expected a number');
+	});
+
+	it('rejects non-boolean value for boolean-type config', async () => {
+		vi.mocked(prisma.systemConfig.findUnique).mockResolvedValue({
+			key: 'maintenance_mode',
+			value: 'false',
+			description: 'Maintenance mode toggle',
+			dataType: 'boolean',
+			updatedAt: new Date(),
+			updatedBy: null,
+		});
+
+		const token = await makeToken();
+		const res = await app.inject({
+			method: 'PUT',
+			url: '/api/v1/system-config',
+			headers: authHeader(token),
+			payload: {
+				updates: [{ key: 'maintenance_mode', value: 'notabool' }],
+			},
+		});
+		expect(res.statusCode).toBe(400);
+		expect(res.json().error).toContain('expected "true" or "false"');
+	});
+
+	it('accepts valid numeric string for number-type config', async () => {
+		vi.mocked(prisma.systemConfig.findUnique).mockResolvedValue(mockConfigs[0]!);
+		vi.mocked(prisma.systemConfig.update).mockResolvedValue({
+			...mockConfigs[0]!,
+			value: '10',
+		});
+
+		const token = await makeToken();
+		const res = await app.inject({
+			method: 'PUT',
+			url: '/api/v1/system-config',
+			headers: authHeader(token),
+			payload: {
+				updates: [{ key: 'lockout_threshold', value: '10' }],
+			},
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.json().updated).toBe(1);
+	});
+
 	it('returns updated count (skips unknown keys)', async () => {
 		vi.mocked(prisma.systemConfig.findUnique)
 			.mockResolvedValueOnce(mockConfigs[0]!)

--- a/apps/api/src/routes/system-config.ts
+++ b/apps/api/src/routes/system-config.ts
@@ -34,7 +34,7 @@ export async function systemConfigRoutes(app: FastifyInstance) {
 	app.put('/', {
 		schema: { body: updateBodySchema },
 		preHandler: [app.authenticate, app.requireRole('Admin')],
-		handler: async (request) => {
+		handler: async (request, reply) => {
 			const { updates } = request.body as z.infer<typeof updateBodySchema>;
 			let updated = 0;
 
@@ -43,6 +43,22 @@ export async function systemConfigRoutes(app: FastifyInstance) {
 					where: { key },
 				});
 				if (!existing) continue;
+
+				// Validate value against declared dataType
+				if (existing.dataType === 'number') {
+					const num = Number(value);
+					if (Number.isNaN(num)) {
+						return reply.status(400).send({
+							error: `Invalid value for "${key}": expected a number`,
+						});
+					}
+				} else if (existing.dataType === 'boolean') {
+					if (!['true', 'false'].includes(value.toLowerCase())) {
+						return reply.status(400).send({
+							error: `Invalid value for "${key}": expected "true" or "false"`,
+						});
+					}
+				}
 
 				const oldValue = existing.value;
 				await prisma.systemConfig.update({


### PR DESCRIPTION
## Summary

Fixes one finding from code review (Epic 13 — System Config):

- **Finding 3 (Medium):** `PUT /system-config` now validates values against the record's `dataType` field before writing. Without this, an admin could store `lockout_threshold='foo'`, which gets coerced to `NaN` by `Number()` in `getConfigValue()`, causing all NaN comparisons to return false and bypassing session limits and account lockout.

Relates to #2

## Changes

| File | Change |
|------|--------|
| `apps/api/src/routes/system-config.ts` | Add dataType validation (number → NaN check, boolean → true/false check), return 400 on invalid |
| `apps/api/src/routes/system-config.test.ts` | 3 new tests: reject non-numeric, reject non-boolean, accept valid numeric |

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — zero errors
- [x] `pnpm test` — 373/373 passing, zero regressions
- [x] `PUT /system-config` with `{ key: 'lockout_threshold', value: 'foo' }` → 400
- [x] `PUT /system-config` with `{ key: 'lockout_threshold', value: '10' }` → 200
- [x] Unknown keys still silently skipped (count excludes them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>