### PR TITLE
fix(epic-7): seed schoolYear config default

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -70,6 +70,12 @@ async function main() {
 			dataType: 'number',
 			description: 'Auto-save interval in seconds',
 		},
+		{
+			key: 'schoolYear',
+			value: '2025-2026',
+			dataType: 'string',
+			description: 'Current school year displayed in context bar',
+		},
 	];
 
 	for (const config of configDefaults) {
@@ -80,7 +86,7 @@ async function main() {
 		});
 	}
 
-	console.log('Seeded 7 system_config defaults.');
+	console.log('Seeded 8 system_config defaults.');
 }
 
 main()


### PR DESCRIPTION
## Summary

- Add `schoolYear` (`'2025-2026'`, dataType `string`) to `configDefaults` in `prisma/seed.ts`
- Update seeded count log from 7 to 8
- Fixes `GET /api/v1/context` returning `schoolYear: null`

Part of Epic 7: Master Data Management (#5)

## Test Plan

- [ ] `pnpm --filter @budfin/api exec prisma db seed` succeeds
- [ ] `GET /api/v1/context` returns `schoolYear: "2025-2026"`
- [ ] `pnpm test` — all 376+ API tests pass

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>