### PR TITLE
fix(epic-7): settings key names match seed data

### DIFF
--- a/apps/web/src/pages/admin/settings.tsx
+++ b/apps/web/src/pages/admin/settings.tsx
@@ -33,7 +33,7 @@ const GROUPS: SettingGroup[] = [
 				label: 'Max Sessions per User',
 			},
 			{
-				key: 'session_timeout',
+				key: 'session_timeout_minutes',
 				label: 'Session Timeout (minutes)',
 			},
 		],
@@ -57,7 +57,7 @@ const GROUPS: SettingGroup[] = [
 		description: 'General application settings',
 		keys: [
 			{
-				key: 'fiscal_year_start',
+				key: 'fiscal_year_start_month',
 				label: 'Fiscal Year Start (month)',
 			},
 			{
@@ -65,7 +65,7 @@ const GROUPS: SettingGroup[] = [
 				label: 'Fiscal Year Range',
 			},
 			{
-				key: 'autosave_interval',
+				key: 'autosave_interval_seconds',
 				label: 'Autosave Interval (seconds)',
 			},
 		],


### PR DESCRIPTION
## Summary

Fixes 3 setting key names in the admin Settings page to match the backend seed data:

- `session_timeout` → `session_timeout_minutes`
- `fiscal_year_start` → `fiscal_year_start_month`
- `autosave_interval` → `autosave_interval_seconds`

Previously these 3 fields appeared empty on the Settings page because the frontend key names didn't match the keys stored in the database by the seed migration.

Part of Epic #5

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — all tests passing
- [x] Verified key names match `apps/api/prisma/seed.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)