### PR TITLE
fix(epic-13): infra cleanup — date utility, ignore files, prod compose

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -11,3 +11,4 @@ docs/prd/
 docs/reviews/
 docs/ui-ux-spec/
 docs/tdd/
+docs/prompt/

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ node_modules/
 pnpm-lock.yaml
 *.tsbuildinfo
 .claude/
+docs/prompt/

--- a/apps/web/src/components/context-bar.tsx
+++ b/apps/web/src/components/context-bar.tsx
@@ -1,9 +1,10 @@
 import { useWorkspaceContext } from '../hooks/use-workspace-context';
 import { useVersions } from '../hooks/use-versions';
+import { getCurrentFiscalYear } from '../lib/format-date';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 
 // Fiscal years available for selection — covers a rolling window around the current year.
-const CURRENT_YEAR = new Date().getFullYear();
+const CURRENT_YEAR = getCurrentFiscalYear();
 const FISCAL_YEARS = Array.from({ length: 5 }, (_, i) => CURRENT_YEAR - 1 + i);
 
 // Academic period options (tied to master-data AY structure)

--- a/apps/web/src/components/enrollment/csv-import-panel.tsx
+++ b/apps/web/src/components/enrollment/csv-import-panel.tsx
@@ -3,6 +3,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '
 import { Button } from '../ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { useImportHistorical, type ImportValidationResult } from '../../hooks/use-enrollment';
+import { getCurrentFiscalYear } from '../../lib/format-date';
 import { AlertTriangle, Check, Upload } from 'lucide-react';
 
 interface CsvImportPanelProps {
@@ -10,7 +11,7 @@ interface CsvImportPanelProps {
 	onClose: () => void;
 }
 
-const CURRENT_YEAR = new Date().getFullYear();
+const CURRENT_YEAR = getCurrentFiscalYear();
 const YEARS = Array.from({ length: 10 }, (_, i) => CURRENT_YEAR - i);
 
 export function CsvImportPanel({ open, onClose }: CsvImportPanelProps) {

--- a/apps/web/src/hooks/use-workspace-context.ts
+++ b/apps/web/src/hooks/use-workspace-context.ts
@@ -1,6 +1,7 @@
 import { useSearchParams } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
+import { getCurrentFiscalYear } from '../lib/format-date';
 
 export interface WorkspaceContext {
 	fiscalYear: number;
@@ -14,7 +15,7 @@ export function useWorkspaceContext() {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const queryClient = useQueryClient();
 
-	const fiscalYear = Number(searchParams.get('fy')) || new Date().getFullYear();
+	const fiscalYear = Number(searchParams.get('fy')) || getCurrentFiscalYear();
 	const versionId = searchParams.get('version') ? Number(searchParams.get('version')) : null;
 	const comparisonVersionId = searchParams.get('compare')
 		? Number(searchParams.get('compare'))

--- a/apps/web/src/lib/format-date.ts
+++ b/apps/web/src/lib/format-date.ts
@@ -14,3 +14,7 @@ export function formatDate(iso: string | null): string {
 	const date = new TZDate(iso, TIMEZONE);
 	return format(date, 'dd MMM yyyy');
 }
+
+export function getCurrentFiscalYear(): number {
+	return new TZDate(Date.now(), TIMEZONE).getFullYear();
+}

--- a/apps/web/src/pages/versions/fiscal-periods.tsx
+++ b/apps/web/src/pages/versions/fiscal-periods.tsx
@@ -6,7 +6,7 @@ import {
 	useReactTable,
 } from '@tanstack/react-table';
 import { cn } from '../../lib/cn';
-import { formatDate } from '../../lib/format-date';
+import { formatDate, getCurrentFiscalYear } from '../../lib/format-date';
 import { useAuthStore } from '../../stores/auth-store';
 import { useFiscalPeriods, useLockFiscalPeriod } from '../../hooks/use-fiscal-periods';
 import type { FiscalPeriod } from '../../hooks/use-fiscal-periods';
@@ -35,7 +35,7 @@ const STATUS_BADGE_COLORS: Record<string, string> = {
 	Locked: 'bg-violet-100 text-violet-800',
 };
 
-const CURRENT_FISCAL_YEAR = new Date().getFullYear();
+const CURRENT_FISCAL_YEAR = getCurrentFiscalYear();
 
 export function FiscalPeriodsPage() {
 	const currentUser = useAuthStore((s) => s.user);

--- a/apps/web/src/pages/versions/versions.tsx
+++ b/apps/web/src/pages/versions/versions.tsx
@@ -10,7 +10,7 @@ import { cn } from '../../lib/cn';
 import { useAuthStore } from '../../stores/auth-store';
 import { useVersions } from '../../hooks/use-versions';
 import type { BudgetVersion } from '../../hooks/use-versions';
-import { formatDate } from '../../lib/format-date';
+import { formatDate, getCurrentFiscalYear } from '../../lib/format-date';
 import { toast } from '../../components/ui/toast-state';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
@@ -62,7 +62,7 @@ const TYPE_DOT_COLORS: Record<BudgetVersion['type'], string> = {
 	Actual: 'bg-green-500',
 };
 
-const CURRENT_FISCAL_YEAR = new Date().getFullYear();
+const CURRENT_FISCAL_YEAR = getCurrentFiscalYear();
 
 export function VersionsPage() {
 	const currentUser = useAuthStore((s) => s.user);

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
       DATABASE_URL: postgresql://app_user:${DB_PASSWORD}@db:5432/budfindb
       JWT_PRIVATE_KEY_PATH: /run/secrets/jwt_private_key
       JWT_PUBLIC_KEY_PATH: /run/secrets/jwt_public_key
-      SALARY_ENCRYPTION_KEY_PATH: /run/secrets/salary_encryption_key
+      SALARY_ENCRYPTION_KEY: /run/secrets/salary_encryption_key
       LOG_LEVEL: info
     secrets:
       - jwt_private_key


### PR DESCRIPTION
## Summary

Infrastructure cleanup addressing codebase audit findings:

- **Date utility**: New `getCurrentFiscalYear()` in `format-date.ts` replaces 5 instances of bare `new Date().getFullYear()` with timezone-aware `TZDate` using Arabia Standard Time (UTC+3)
- **Prod compose fix**: Corrects env var name from `SALARY_ENCRYPTION_KEY_PATH` to `SALARY_ENCRYPTION_KEY` to match dev compose and `.env.example`
- **Linter ignores**: Adds `docs/prompt/` to `.prettierignore` and `.markdownlintignore`

Part of Epic #2

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — all 471 tests passing
- [x] No remaining `new Date().getFullYear()` in frontend source
- [x] `SALARY_ENCRYPTION_KEY` consistent across all compose files

🤖 Generated with [Claude Code](https://claude.com/claude-code)