### PR TITLE
feat(staffing): encrypted field masking and ARIA attributes for grids

### DIFF
--- a/apps/web/src/components/staffing/employee-grid.test.tsx
+++ b/apps/web/src/components/staffing/employee-grid.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { EmployeeGrid } from './employee-grid';
+import type { Employee } from '../../hooks/use-staffing';
+
+function makeEmployee(overrides: Partial<Employee> = {}): Employee {
+	return {
+		id: 1,
+		employeeCode: 'EMP-001',
+		name: 'Alice Martin',
+		functionRole: 'Teacher',
+		department: 'Primary',
+		status: 'Existing',
+		joiningDate: '2022-09-01',
+		paymentMethod: 'Bank',
+		isSaudi: true,
+		isAjeer: false,
+		isTeaching: true,
+		hourlyPercentage: '1.0000',
+		baseSalary: '10000',
+		housingAllowance: '2500',
+		transportAllowance: '500',
+		responsibilityPremium: '1000',
+		hsaAmount: '300',
+		augmentation: '500',
+		augmentationEffectiveDate: '2026-09-01',
+		ajeerAnnualLevy: '0',
+		ajeerMonthlyFee: '0',
+		updatedAt: '2026-03-01T00:00:00Z',
+		...overrides,
+	};
+}
+
+describe('EmployeeGrid', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	describe('salary field masking for Viewer role', () => {
+		it('shows salary column when isReadOnly is false', () => {
+			const emp = makeEmployee();
+			render(
+				<EmployeeGrid employees={[emp]} isReadOnly={false} onSelect={vi.fn()} selectedId={null} />
+			);
+
+			expect(screen.getByText('Base Salary')).toBeDefined();
+			expect(screen.getByText(/10,000/)).toBeDefined();
+		});
+
+		it('shows masked "--" for salary fields when isReadOnly is true and salary is null', () => {
+			const emp = makeEmployee({
+				baseSalary: null,
+				housingAllowance: null,
+				transportAllowance: null,
+				responsibilityPremium: null,
+				hsaAmount: null,
+			});
+			render(
+				<EmployeeGrid employees={[emp]} isReadOnly={true} onSelect={vi.fn()} selectedId={null} />
+			);
+
+			// Should show masked salary column with "--" text
+			const maskedCells = screen.getAllByText('--');
+			expect(maskedCells.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('adds aria-label="Salary data restricted" on masked salary cells', () => {
+			const emp = makeEmployee({
+				baseSalary: null,
+				housingAllowance: null,
+				transportAllowance: null,
+				responsibilityPremium: null,
+				hsaAmount: null,
+			});
+			render(
+				<EmployeeGrid employees={[emp]} isReadOnly={true} onSelect={vi.fn()} selectedId={null} />
+			);
+
+			const restricted = screen.getAllByLabelText('Salary data restricted');
+			expect(restricted.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('keeps non-salary columns visible for Viewers', () => {
+			const emp = makeEmployee({ baseSalary: null });
+			render(
+				<EmployeeGrid employees={[emp]} isReadOnly={true} onSelect={vi.fn()} selectedId={null} />
+			);
+
+			// Non-salary columns should be present
+			expect(screen.getByText('Code')).toBeDefined();
+			expect(screen.getByText('Name')).toBeDefined();
+			expect(screen.getByText('Department')).toBeDefined();
+			expect(screen.getByText('Role')).toBeDefined();
+			expect(screen.getByText('Status')).toBeDefined();
+		});
+	});
+
+	describe('ARIA attributes', () => {
+		it('has role="grid" on table element', () => {
+			render(
+				<EmployeeGrid
+					employees={[makeEmployee()]}
+					isReadOnly={false}
+					onSelect={vi.fn()}
+					selectedId={null}
+				/>
+			);
+
+			expect(screen.getByRole('grid')).toBeDefined();
+		});
+
+		it('has aria-label on the grid', () => {
+			render(
+				<EmployeeGrid
+					employees={[makeEmployee()]}
+					isReadOnly={false}
+					onSelect={vi.fn()}
+					selectedId={null}
+				/>
+			);
+
+			const grid = screen.getByRole('grid');
+			expect(grid.getAttribute('aria-label')).toBeTruthy();
+		});
+
+		it('has aria-rowcount and aria-colcount on the grid', () => {
+			const employees = [makeEmployee(), makeEmployee({ id: 2, employeeCode: 'EMP-002' })];
+			render(
+				<EmployeeGrid
+					employees={employees}
+					isReadOnly={false}
+					onSelect={vi.fn()}
+					selectedId={null}
+				/>
+			);
+
+			const grid = screen.getByRole('grid');
+			expect(grid.getAttribute('aria-rowcount')).toBeTruthy();
+			expect(grid.getAttribute('aria-colcount')).toBeTruthy();
+		});
+
+		it('has aria-colindex on cells', () => {
+			render(
+				<EmployeeGrid
+					employees={[makeEmployee()]}
+					isReadOnly={false}
+					onSelect={vi.fn()}
+					selectedId={null}
+				/>
+			);
+
+			const cells = screen.getAllByRole('gridcell');
+			expect(cells.length).toBeGreaterThan(0);
+			expect(cells[0]!.getAttribute('aria-colindex')).toBeTruthy();
+		});
+
+		it('has aria-readonly="true" on non-editable cells', () => {
+			render(
+				<EmployeeGrid
+					employees={[makeEmployee()]}
+					isReadOnly={true}
+					onSelect={vi.fn()}
+					selectedId={null}
+				/>
+			);
+
+			const cells = screen.getAllByRole('gridcell');
+			// All cells in read-only mode should have aria-readonly
+			const readonlyCells = cells.filter((cell) => cell.getAttribute('aria-readonly') === 'true');
+			expect(readonlyCells.length).toBeGreaterThan(0);
+		});
+	});
+});

--- a/apps/web/src/components/staffing/employee-grid.tsx
+++ b/apps/web/src/components/staffing/employee-grid.tsx
@@ -73,14 +73,29 @@ export function EmployeeGrid({ employees, isReadOnly, onSelect, selectedId }: Em
 				cell: (info) => (info.getValue() ? 'Yes' : 'No'),
 			}),
 			...(isReadOnly
-				? []
+				? [
+						columnHelper.accessor('baseSalary', {
+							header: 'Base Salary',
+							size: 110,
+							cell: (info) => {
+								const val = info.getValue();
+								return val === null ? (
+									<span className="text-[var(--text-muted)]" aria-label="Salary data restricted">
+										--
+									</span>
+								) : (
+									`SAR ${Number(val).toLocaleString()}`
+								);
+							},
+						}),
+					]
 				: [
 						columnHelper.accessor('baseSalary', {
 							header: 'Base Salary',
 							size: 110,
 							cell: (info) => {
 								const val = info.getValue();
-								return val ? `SAR ${Number(val).toLocaleString()}` : '—';
+								return val ? `SAR ${Number(val).toLocaleString()}` : '\u2014';
 							},
 						}),
 					]),
@@ -98,6 +113,9 @@ export function EmployeeGrid({ employees, isReadOnly, onSelect, selectedId }: Em
 		getSortedRowModel: getSortedRowModel(),
 		getFilteredRowModel: getFilteredRowModel(),
 	});
+
+	const visibleColumnCount = columns.length;
+	const totalRowCount = table.getFilteredRowModel().rows.length + 1; // +1 for header row
 
 	return (
 		<div className="space-y-3">
@@ -117,11 +135,17 @@ export function EmployeeGrid({ employees, isReadOnly, onSelect, selectedId }: Em
 			/>
 
 			<div className="overflow-x-auto rounded-[var(--radius-md)] border border-[var(--workspace-border)]">
-				<table className="w-full border-collapse text-sm" role="grid">
+				<table
+					className="w-full border-collapse text-sm"
+					role="grid"
+					aria-label="Employee roster"
+					aria-rowcount={totalRowCount}
+					aria-colcount={visibleColumnCount}
+				>
 					<thead>
 						{table.getHeaderGroups().map((headerGroup) => (
 							<tr key={headerGroup.id} className="bg-[var(--workspace-bg-subtle)]">
-								{headerGroup.headers.map((header) => (
+								{headerGroup.headers.map((header, colIdx) => (
 									<th
 										key={header.id}
 										className={cn(
@@ -139,12 +163,13 @@ export function EmployeeGrid({ employees, isReadOnly, onSelect, selectedId }: Em
 													? 'descending'
 													: 'none'
 										}
+										aria-colindex={colIdx + 1}
 									>
 										{flexRender(header.column.columnDef.header, header.getContext())}
 										{header.column.getIsSorted() === 'asc'
-											? ' ↑'
+											? ' \u2191'
 											: header.column.getIsSorted() === 'desc'
-												? ' ↓'
+												? ' \u2193'
 												: ''}
 									</th>
 								))}
@@ -181,9 +206,12 @@ export function EmployeeGrid({ employees, isReadOnly, onSelect, selectedId }: Em
 										}
 									}}
 								>
-									{row.getVisibleCells().map((cell) => (
+									{row.getVisibleCells().map((cell, colIdx) => (
 										<td
 											key={cell.id}
+											role="gridcell"
+											aria-colindex={colIdx + 1}
+											aria-readonly={isReadOnly ? 'true' : undefined}
 											className={cn(
 												'px-3 py-2 text-[var(--text-primary)]',
 												'border-b border-[var(--workspace-border)]'

--- a/apps/web/src/components/staffing/monthly-cost-grid.test.tsx
+++ b/apps/web/src/components/staffing/monthly-cost-grid.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { MonthlyCostGrid } from './monthly-cost-grid';
+import type { StaffCostRow } from '../../hooks/use-staffing';
+
+function makeRow(overrides: Partial<StaffCostRow> = {}): StaffCostRow {
+	return {
+		group_key: 'January',
+		total_gross_salary: '50000',
+		total_allowances: '15000',
+		total_social_charges: '5875',
+		total_staff_cost: '70875',
+		...overrides,
+	};
+}
+
+const defaultTotals = {
+	total_gross_salary: '600000',
+	total_allowances: '180000',
+	total_social_charges: '70500',
+	total_staff_cost: '850500',
+};
+
+describe('MonthlyCostGrid', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	describe('redacted mode', () => {
+		it('hides Gross Salary and Allowances columns when isRedacted is true', () => {
+			render(<MonthlyCostGrid data={[makeRow()]} totals={defaultTotals} isRedacted={true} />);
+
+			expect(screen.queryByText('Gross Salary')).toBeNull();
+			expect(screen.queryByText('Allowances')).toBeNull();
+		});
+
+		it('shows Social Charges and Total Cost when isRedacted is true', () => {
+			render(<MonthlyCostGrid data={[makeRow()]} totals={defaultTotals} isRedacted={true} />);
+
+			expect(screen.getByText('Social Charges')).toBeDefined();
+			expect(screen.getByText('Total Cost')).toBeDefined();
+		});
+
+		it('shows all columns when isRedacted is false', () => {
+			render(<MonthlyCostGrid data={[makeRow()]} totals={defaultTotals} isRedacted={false} />);
+
+			expect(screen.getByText('Gross Salary')).toBeDefined();
+			expect(screen.getByText('Allowances')).toBeDefined();
+			expect(screen.getByText('Social Charges')).toBeDefined();
+			expect(screen.getByText('Total Cost')).toBeDefined();
+		});
+	});
+
+	describe('ARIA attributes', () => {
+		it('has role="grid" on table element', () => {
+			render(<MonthlyCostGrid data={[makeRow()]} totals={defaultTotals} isRedacted={false} />);
+
+			expect(screen.getByRole('grid')).toBeDefined();
+		});
+
+		it('has aria-label on the grid', () => {
+			render(<MonthlyCostGrid data={[makeRow()]} totals={defaultTotals} isRedacted={false} />);
+
+			const grid = screen.getByRole('grid');
+			expect(grid.getAttribute('aria-label')).toBeTruthy();
+		});
+
+		it('has aria-readonly="true" on the grid', () => {
+			render(<MonthlyCostGrid data={[makeRow()]} totals={defaultTotals} isRedacted={false} />);
+
+			const grid = screen.getByRole('grid');
+			expect(grid.getAttribute('aria-readonly')).toBe('true');
+		});
+
+		it('has aria-rowcount and aria-colcount on the grid', () => {
+			const rows = [makeRow(), makeRow({ group_key: 'February' })];
+			render(<MonthlyCostGrid data={rows} totals={defaultTotals} isRedacted={false} />);
+
+			const grid = screen.getByRole('grid');
+			expect(grid.getAttribute('aria-rowcount')).toBeTruthy();
+			expect(grid.getAttribute('aria-colcount')).toBeTruthy();
+		});
+
+		it('has aria-colindex on cells', () => {
+			render(<MonthlyCostGrid data={[makeRow()]} totals={defaultTotals} isRedacted={false} />);
+
+			const cells = screen.getAllByRole('gridcell');
+			expect(cells.length).toBeGreaterThan(0);
+			expect(cells[0]!.getAttribute('aria-colindex')).toBeTruthy();
+		});
+	});
+
+	describe('empty state', () => {
+		it('shows empty message when data is empty', () => {
+			render(<MonthlyCostGrid data={[]} totals={null} isRedacted={false} />);
+
+			expect(screen.getByText(/No staff cost data available/)).toBeDefined();
+		});
+	});
+});

--- a/apps/web/src/components/staffing/monthly-cost-grid.tsx
+++ b/apps/web/src/components/staffing/monthly-cost-grid.tsx
@@ -15,7 +15,7 @@ export type MonthlyCostGridProps = {
 };
 
 function formatSar(val: string | null): string {
-	if (val === null) return '—';
+	if (val === null) return '\u2014';
 	return `SAR ${Number(val).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
 }
 
@@ -31,6 +31,10 @@ export function MonthlyCostGrid({ data, totals, isRedacted }: MonthlyCostGridPro
 			</div>
 		);
 	}
+
+	const visibleColCount = isRedacted ? 3 : 5;
+	// +1 for header row, +1 for totals footer row if present
+	const totalRowCount = data.length + 1 + (totals ? 1 : 0);
 
 	return (
 		<div className="space-y-3">
@@ -53,10 +57,20 @@ export function MonthlyCostGrid({ data, totals, isRedacted }: MonthlyCostGridPro
 			</div>
 
 			<div className="overflow-x-auto rounded-[var(--radius-md)] border border-[var(--workspace-border)]">
-				<table className="w-full border-collapse text-sm" role="grid">
+				<table
+					className="w-full border-collapse text-sm"
+					role="grid"
+					aria-label="Monthly staff costs"
+					aria-readonly="true"
+					aria-rowcount={totalRowCount}
+					aria-colcount={visibleColCount}
+				>
 					<thead>
 						<tr className="bg-[var(--workspace-bg-subtle)]">
-							<th className="px-3 py-2 text-left text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider">
+							<th
+								className="px-3 py-2 text-left text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider"
+								aria-colindex={1}
+							>
 								{groupBy === 'month'
 									? 'Month'
 									: groupBy === 'department'
@@ -65,52 +79,87 @@ export function MonthlyCostGrid({ data, totals, isRedacted }: MonthlyCostGridPro
 							</th>
 							{!isRedacted && (
 								<>
-									<th className="px-3 py-2 text-right text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider">
+									<th
+										className="px-3 py-2 text-right text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider"
+										aria-colindex={2}
+									>
 										Gross Salary
 									</th>
-									<th className="px-3 py-2 text-right text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider">
+									<th
+										className="px-3 py-2 text-right text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider"
+										aria-colindex={3}
+									>
 										Allowances
 									</th>
 								</>
 							)}
-							<th className="px-3 py-2 text-right text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider">
+							<th
+								className="px-3 py-2 text-right text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider"
+								aria-colindex={isRedacted ? 2 : 4}
+							>
 								Social Charges
 							</th>
-							<th className="px-3 py-2 text-right text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider">
+							<th
+								className="px-3 py-2 text-right text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider"
+								aria-colindex={isRedacted ? 3 : 5}
+							>
 								Total Cost
 							</th>
 						</tr>
 					</thead>
 					<tbody>
-						{data.map((row) => (
-							<tr
-								key={row.group_key}
-								className={cn(
-									'border-t border-[var(--workspace-border)]',
-									'hover:bg-[var(--workspace-bg-subtle)]'
-								)}
-							>
-								<td className="px-3 py-1.5 font-medium text-[var(--text-primary)]">
-									{row.group_key}
-								</td>
-								{!isRedacted && (
-									<>
-										<td className="px-3 py-1.5 text-right font-mono text-[var(--text-primary)]">
-											{formatSar(row.total_gross_salary)}
-										</td>
-										<td className="px-3 py-1.5 text-right font-mono text-[var(--text-primary)]">
-											{formatSar(row.total_allowances)}
-										</td>
-									</>
-								)}
-								<td className="px-3 py-1.5 text-right font-mono text-[var(--text-primary)]">
-									{formatSar(row.total_social_charges)}
-								</td>
-								<td className="px-3 py-1.5 text-right font-mono font-medium text-[var(--accent-700)]">
-									{formatSar(row.total_staff_cost)}
-								</td>
-							</tr>
-						))}
+						{data.map((row) => {
+							let colCounter = 0;
+							return (
+								<tr
+									key={row.group_key}
+									className={cn(
+										'border-t border-[var(--workspace-border)]',
+										'hover:bg-[var(--workspace-bg-subtle)]'
+									)}
+								>
+									<td
+										role="gridcell"
+										aria-colindex={++colCounter}
+										className="px-3 py-1.5 font-medium text-[var(--text-primary)]"
+									>
+										{row.group_key}
+									</td>
+									{!isRedacted && (
+										<>
+											<td
+												role="gridcell"
+												aria-colindex={++colCounter}
+												className="px-3 py-1.5 text-right font-mono text-[var(--text-primary)]"
+											>
+												{formatSar(row.total_gross_salary)}
+											</td>
+											<td
+												role="gridcell"
+												aria-colindex={++colCounter}
+												className="px-3 py-1.5 text-right font-mono text-[var(--text-primary)]"
+											>
+												{formatSar(row.total_allowances)}
+											</td>
+										</>
+									)}
+									<td
+										role="gridcell"
+										aria-colindex={++colCounter}
+										className="px-3 py-1.5 text-right font-mono text-[var(--text-primary)]"
+									>
+										{formatSar(row.total_social_charges)}
+									</td>
+									<td
+										role="gridcell"
+										aria-colindex={++colCounter}
+										className="px-3 py-1.5 text-right font-mono font-medium text-[var(--accent-700)]"
+									>
+										{formatSar(row.total_staff_cost)}
+									</td>
+								</tr>
+							);
+						})}
 					</tbody>
 					{totals && (
 						<tfoot>


### PR DESCRIPTION
## Summary

- When `isReadOnly` is true (Viewer role), salary fields with `null` values now display `--` with `aria-label="Salary data restricted"` in the EmployeeGrid, instead of hiding the column entirely
- Both EmployeeGrid (Tab B) and MonthlyCostGrid (Tab C) now have proper ARIA grid attributes: `aria-label`, `aria-rowcount`, `aria-colcount`, `aria-colindex` on cells, and `aria-readonly` where applicable
- 18 new tests covering masking behavior and ARIA attribute presence

Fixes #169
Part of Epic #8

## Test plan

- [x] Verify salary column shows `--` for null salary values when `isReadOnly=true`
- [x] Verify `aria-label="Salary data restricted"` on masked cells
- [x] Verify non-salary columns remain visible for Viewers
- [x] Verify `aria-label`, `aria-rowcount`, `aria-colcount` on both grids
- [x] Verify `aria-colindex` on all cells
- [x] Verify `aria-readonly="true"` on MonthlyCostGrid and on read-only EmployeeGrid cells
- [x] All 775 tests pass (701 API + 74 web)
- [x] TypeScript: zero errors
- [x] ESLint: zero errors, zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)