### PR TITLE
feat(staffing): Monthly Cost Budget grid with 12-month category hierarchy

### DIFF
--- a/apps/web/src/components/staffing/monthly-cost-budget-grid.test.tsx
+++ b/apps/web/src/components/staffing/monthly-cost-budget-grid.test.tsx
@@ -1,0 +1,478 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MonthlyCostBudgetGrid } from './monthly-cost-budget-grid';
+import type { CategoryMonthData } from '../../hooks/use-staffing';
+
+// Mock ResizeObserver for jsdom
+class MockResizeObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+
+beforeEach(() => {
+	globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+	cleanup();
+});
+
+function buildMockData(): CategoryMonthData {
+	const zeroMonths = [
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+	];
+
+	return {
+		months: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+		categories: [
+			{
+				key: 'gross_salaries_existing',
+				label: 'Existing Staff',
+				monthly_amounts: [
+					'10000.0000',
+					'10000.0000',
+					'10000.0000',
+					'10000.0000',
+					'10000.0000',
+					'10000.0000',
+					'10000.0000',
+					'10000.0000',
+					'11000.0000',
+					'11000.0000',
+					'11000.0000',
+					'11000.0000',
+				],
+				annual_total: '124000.0000',
+			},
+			{
+				key: 'gross_salaries_new',
+				label: 'New Staff',
+				monthly_amounts: [
+					'0.0000',
+					'0.0000',
+					'0.0000',
+					'0.0000',
+					'0.0000',
+					'0.0000',
+					'0.0000',
+					'0.0000',
+					'5000.0000',
+					'5000.0000',
+					'5000.0000',
+					'5000.0000',
+				],
+				annual_total: '20000.0000',
+			},
+			{
+				key: 'gosi',
+				label: 'GOSI',
+				monthly_amounts: [
+					'1175.0000',
+					'1175.0000',
+					'1175.0000',
+					'1175.0000',
+					'1175.0000',
+					'1175.0000',
+					'1175.0000',
+					'1175.0000',
+					'1880.0000',
+					'1880.0000',
+					'1880.0000',
+					'1880.0000',
+				],
+				annual_total: '16920.0000',
+			},
+			{
+				key: 'ajeer',
+				label: 'Ajeer',
+				monthly_amounts: zeroMonths,
+				annual_total: '0.0000',
+			},
+			{
+				key: 'eos_accrual',
+				label: 'EoS Accrual',
+				monthly_amounts: [
+					'500.0000',
+					'500.0000',
+					'500.0000',
+					'500.0000',
+					'500.0000',
+					'500.0000',
+					'500.0000',
+					'500.0000',
+					'600.0000',
+					'600.0000',
+					'600.0000',
+					'600.0000',
+				],
+				annual_total: '6400.0000',
+			},
+		],
+		annual_totals: {
+			gross_salaries_existing: '124000.0000',
+			gross_salaries_new: '20000.0000',
+			gosi: '16920.0000',
+			ajeer: '0.0000',
+			eos_accrual: '6400.0000',
+		},
+	};
+}
+
+function buildMockCategoryCosts() {
+	const zeroMonths = [
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+		'0.0000',
+	];
+
+	return {
+		categories: [
+			{
+				key: 'remplacements',
+				label: 'Remplacements',
+				monthly_amounts: [
+					'2000.0000',
+					'2000.0000',
+					'2000.0000',
+					'2000.0000',
+					'2000.0000',
+					'2000.0000',
+					'2000.0000',
+					'2000.0000',
+					'2000.0000',
+					'2000.0000',
+					'2000.0000',
+					'2000.0000',
+				],
+				annual_total: '24000.0000',
+			},
+			{
+				key: 'formation',
+				label: 'Formation',
+				monthly_amounts: [
+					'100.0000',
+					'100.0000',
+					'100.0000',
+					'100.0000',
+					'100.0000',
+					'100.0000',
+					'100.0000',
+					'100.0000',
+					'100.0000',
+					'100.0000',
+					'100.0000',
+					'100.0000',
+				],
+				annual_total: '1200.0000',
+			},
+			{
+				key: 'resident_salaires',
+				label: 'Resident Salaires',
+				monthly_amounts: [
+					'3000.0000',
+					'3000.0000',
+					'3000.0000',
+					'3000.0000',
+					'3000.0000',
+					'3000.0000',
+					'3000.0000',
+					'3000.0000',
+					'3000.0000',
+					'3000.0000',
+					'3000.0000',
+					'3000.0000',
+				],
+				annual_total: '36000.0000',
+			},
+			{
+				key: 'resident_logement',
+				label: 'Resident Logement',
+				monthly_amounts: zeroMonths,
+				annual_total: '0.0000',
+			},
+		],
+	};
+}
+
+describe('MonthlyCostBudgetGrid', () => {
+	// AC-10: Grid displays 12-month columns + annual total
+	describe('AC-10: 12-month columns + annual total', () => {
+		it('renders all 12 month column headers (Jan-Dec)', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			const monthNames = [
+				'Jan',
+				'Feb',
+				'Mar',
+				'Apr',
+				'May',
+				'Jun',
+				'Jul',
+				'Aug',
+				'Sep',
+				'Oct',
+				'Nov',
+				'Dec',
+			];
+			for (const month of monthNames) {
+				expect(screen.getByText(month)).toBeDefined();
+			}
+		});
+
+		it('renders the Annual Total column header', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			expect(screen.getByText('Annual')).toBeDefined();
+		});
+
+		it('renders the Category column header', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			expect(screen.getByText('Category')).toBeDefined();
+		});
+
+		it('uses aria grid role for accessibility', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			expect(screen.getByRole('grid')).toBeDefined();
+		});
+
+		it('sets aria-readonly on the grid', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			expect(screen.getByRole('grid').getAttribute('aria-readonly')).toBe('true');
+		});
+	});
+
+	// AC-11: Category hierarchy with expandable parent rows
+	describe('AC-11: Category hierarchy with expandable parent rows', () => {
+		it('renders Local Staff Salaries parent row', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			expect(screen.getByText('Local Staff Salaries')).toBeDefined();
+		});
+
+		it('renders child rows: Existing Staff and New Staff under Local Staff Salaries', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			expect(screen.getByText('Existing Staff')).toBeDefined();
+			expect(screen.getByText('New Staff')).toBeDefined();
+		});
+
+		it('renders Social Charges parent rows: GOSI, Ajeer, EoS Accrual', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			expect(screen.getByText('GOSI')).toBeDefined();
+			expect(screen.getByText('Ajeer')).toBeDefined();
+			expect(screen.getByText('EoS Accrual')).toBeDefined();
+		});
+
+		it('renders Subtotal Local Staff row', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			expect(screen.getByText('Subtotal Local Staff')).toBeDefined();
+		});
+
+		it('renders Contrats Locaux parent row with children', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			expect(screen.getByText('Contrats Locaux')).toBeDefined();
+			expect(screen.getByText('Remplacements')).toBeDefined();
+			expect(screen.getByText('Formation')).toBeDefined();
+		});
+
+		it('renders Residents parent row with children', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			expect(screen.getByText('Residents')).toBeDefined();
+			expect(screen.getByText('Resident Salaires')).toBeDefined();
+			expect(screen.getByText('Resident Logement')).toBeDefined();
+		});
+
+		it('allows toggling expandable parent rows', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			// Local Staff Salaries should be expandable
+			const toggleButton = screen.getByRole('button', {
+				name: /Local Staff Salaries/i,
+			});
+			expect(toggleButton).toBeDefined();
+
+			// Initially expanded -- children visible
+			expect(screen.getByText('Existing Staff')).toBeDefined();
+
+			// Collapse
+			fireEvent.click(toggleButton);
+
+			// After collapse, the child rows should be hidden
+			expect(screen.queryByText('Existing Staff')).toBeNull();
+		});
+	});
+
+	// AC-12: Grand total row sums all categories
+	describe('AC-12: Grand total row', () => {
+		it('renders the Grand Total row', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			expect(screen.getByText('GRAND TOTAL')).toBeDefined();
+		});
+
+		it('displays formatted currency values in the Grand Total annual cell', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			// Grand total annual = staff costs (124000 + 20000 + 16920 + 0 + 6400) +
+			// category costs (24000 + 1200 + 36000 + 0) = 228,520
+			// Check that the formatted value appears somewhere in the grid
+			const grandTotalRow = screen.getByText('GRAND TOTAL').closest('tr');
+			expect(grandTotalRow).not.toBeNull();
+			expect(grandTotalRow!.textContent).toContain('228,520');
+		});
+	});
+
+	// Edge case: loading state
+	describe('Loading state', () => {
+		it('renders skeleton when isLoading is true', () => {
+			render(
+				<MonthlyCostBudgetGrid staffCostData={null} categoryCostData={null} isLoading={true} />
+			);
+
+			// Should show skeleton loading elements
+			const skeletons = screen.getAllByRole('row', { hidden: true });
+			expect(skeletons.length).toBeGreaterThan(0);
+		});
+	});
+
+	// Edge case: empty data
+	describe('Empty data', () => {
+		it('shows empty state message when no data available', () => {
+			render(
+				<MonthlyCostBudgetGrid staffCostData={null} categoryCostData={null} isLoading={false} />
+			);
+
+			expect(screen.getByText(/No staff cost data available/i)).toBeDefined();
+		});
+	});
+
+	// TC-001: Currency formatting uses Decimal.js
+	describe('TC-001: Decimal.js currency formatting', () => {
+		it('formats monetary values with SAR prefix and proper grouping', () => {
+			render(
+				<MonthlyCostBudgetGrid
+					staffCostData={buildMockData()}
+					categoryCostData={buildMockCategoryCosts()}
+					isLoading={false}
+				/>
+			);
+
+			// Existing Staff annual total is 124,000 -- should appear formatted
+			const existingStaffRow = screen.getByText('Existing Staff').closest('tr');
+			expect(existingStaffRow).not.toBeNull();
+			expect(existingStaffRow!.textContent).toContain('124,000');
+		});
+	});
+});

--- a/apps/web/src/components/staffing/monthly-cost-budget-grid.tsx
+++ b/apps/web/src/components/staffing/monthly-cost-budget-grid.tsx
@@ -1,0 +1,441 @@
+import { useState, useMemo } from 'react';
+import Decimal from 'decimal.js';
+import { cn } from '../../lib/cn';
+import { Skeleton } from '../ui/skeleton';
+import type {
+	CategoryMonthData,
+	CategoryCostData,
+	CategoryMonthEntry,
+} from '../../hooks/use-staffing';
+
+export type MonthlyCostBudgetGridProps = {
+	staffCostData: CategoryMonthData | null;
+	categoryCostData: CategoryCostData | null;
+	isLoading: boolean;
+};
+
+const MONTH_LABELS = [
+	'Jan',
+	'Feb',
+	'Mar',
+	'Apr',
+	'May',
+	'Jun',
+	'Jul',
+	'Aug',
+	'Sep',
+	'Oct',
+	'Nov',
+	'Dec',
+];
+
+type RowType = 'parent' | 'child' | 'subtotal' | 'grand-total';
+
+interface GridRow {
+	id: string;
+	label: string;
+	type: RowType;
+	parentId?: string;
+	monthlyAmounts: string[];
+	annualTotal: string;
+}
+
+function formatCurrency(value: string): string {
+	const d = new Decimal(value);
+	const rounded = d.toDecimalPlaces(0, Decimal.ROUND_HALF_UP);
+	return rounded.toNumber().toLocaleString('en-US', {
+		minimumFractionDigits: 0,
+		maximumFractionDigits: 0,
+	});
+}
+
+function sumMonthlyArrays(arrays: string[][]): string[] {
+	if (arrays.length === 0) {
+		return Array.from({ length: 12 }, () => '0.0000');
+	}
+	return Array.from({ length: 12 }, (_, i) => {
+		let sum = new Decimal(0);
+		for (const arr of arrays) {
+			if (arr[i]) {
+				sum = sum.plus(arr[i]);
+			}
+		}
+		return sum.toFixed(4);
+	});
+}
+
+function sumAnnuals(totals: string[]): string {
+	let sum = new Decimal(0);
+	for (const t of totals) {
+		sum = sum.plus(t);
+	}
+	return sum.toFixed(4);
+}
+
+function findCategory(categories: CategoryMonthEntry[], key: string): CategoryMonthEntry | null {
+	return categories.find((c) => c.key === key) ?? null;
+}
+
+function buildGridRows(
+	staffCostData: CategoryMonthData,
+	categoryCostData: CategoryCostData | null
+): GridRow[] {
+	const rows: GridRow[] = [];
+	const zeroMonths = Array.from({ length: 12 }, () => '0.0000');
+
+	// -- Local Staff Salaries (parent) --
+	const existingStaff = findCategory(staffCostData.categories, 'gross_salaries_existing');
+	const newStaff = findCategory(staffCostData.categories, 'gross_salaries_new');
+
+	const localStaffMonthly = sumMonthlyArrays([
+		existingStaff?.monthly_amounts ?? zeroMonths,
+		newStaff?.monthly_amounts ?? zeroMonths,
+	]);
+	const localStaffAnnual = sumAnnuals([
+		existingStaff?.annual_total ?? '0.0000',
+		newStaff?.annual_total ?? '0.0000',
+	]);
+
+	rows.push({
+		id: 'local_staff_salaries',
+		label: 'Local Staff Salaries',
+		type: 'parent',
+		monthlyAmounts: localStaffMonthly,
+		annualTotal: localStaffAnnual,
+	});
+	rows.push({
+		id: 'existing_staff',
+		label: 'Existing Staff',
+		type: 'child',
+		parentId: 'local_staff_salaries',
+		monthlyAmounts: existingStaff?.monthly_amounts ?? zeroMonths,
+		annualTotal: existingStaff?.annual_total ?? '0.0000',
+	});
+	rows.push({
+		id: 'new_staff',
+		label: 'New Staff',
+		type: 'child',
+		parentId: 'local_staff_salaries',
+		monthlyAmounts: newStaff?.monthly_amounts ?? zeroMonths,
+		annualTotal: newStaff?.annual_total ?? '0.0000',
+	});
+
+	// -- GOSI, Ajeer, EoS Accrual (level 1 rows) --
+	const gosi = findCategory(staffCostData.categories, 'gosi');
+	const ajeer = findCategory(staffCostData.categories, 'ajeer');
+	const eos = findCategory(staffCostData.categories, 'eos_accrual');
+
+	rows.push({
+		id: 'gosi',
+		label: 'GOSI',
+		type: 'child',
+		monthlyAmounts: gosi?.monthly_amounts ?? zeroMonths,
+		annualTotal: gosi?.annual_total ?? '0.0000',
+	});
+	rows.push({
+		id: 'ajeer',
+		label: 'Ajeer',
+		type: 'child',
+		monthlyAmounts: ajeer?.monthly_amounts ?? zeroMonths,
+		annualTotal: ajeer?.annual_total ?? '0.0000',
+	});
+	rows.push({
+		id: 'eos_accrual',
+		label: 'EoS Accrual',
+		type: 'child',
+		monthlyAmounts: eos?.monthly_amounts ?? zeroMonths,
+		annualTotal: eos?.annual_total ?? '0.0000',
+	});
+
+	// -- Subtotal Local Staff --
+	const subtotalMonthly = sumMonthlyArrays([
+		localStaffMonthly,
+		gosi?.monthly_amounts ?? zeroMonths,
+		ajeer?.monthly_amounts ?? zeroMonths,
+		eos?.monthly_amounts ?? zeroMonths,
+	]);
+	const subtotalAnnual = sumAnnuals([
+		localStaffAnnual,
+		gosi?.annual_total ?? '0.0000',
+		ajeer?.annual_total ?? '0.0000',
+		eos?.annual_total ?? '0.0000',
+	]);
+
+	rows.push({
+		id: 'subtotal_local_staff',
+		label: 'Subtotal Local Staff',
+		type: 'subtotal',
+		monthlyAmounts: subtotalMonthly,
+		annualTotal: subtotalAnnual,
+	});
+
+	// -- Contrats Locaux (parent) --
+	const catCosts = categoryCostData?.categories ?? [];
+	const remplacements = findCategory(catCosts, 'remplacements');
+	const formation = findCategory(catCosts, 'formation');
+
+	const contratsMonthly = sumMonthlyArrays([
+		remplacements?.monthly_amounts ?? zeroMonths,
+		formation?.monthly_amounts ?? zeroMonths,
+	]);
+	const contratsAnnual = sumAnnuals([
+		remplacements?.annual_total ?? '0.0000',
+		formation?.annual_total ?? '0.0000',
+	]);
+
+	rows.push({
+		id: 'contrats_locaux',
+		label: 'Contrats Locaux',
+		type: 'parent',
+		monthlyAmounts: contratsMonthly,
+		annualTotal: contratsAnnual,
+	});
+	rows.push({
+		id: 'remplacements',
+		label: 'Remplacements',
+		type: 'child',
+		parentId: 'contrats_locaux',
+		monthlyAmounts: remplacements?.monthly_amounts ?? zeroMonths,
+		annualTotal: remplacements?.annual_total ?? '0.0000',
+	});
+	rows.push({
+		id: 'formation',
+		label: 'Formation',
+		type: 'child',
+		parentId: 'contrats_locaux',
+		monthlyAmounts: formation?.monthly_amounts ?? zeroMonths,
+		annualTotal: formation?.annual_total ?? '0.0000',
+	});
+
+	// -- Residents (parent) --
+	const residentSalaires = findCategory(catCosts, 'resident_salaires');
+	const residentLogement = findCategory(catCosts, 'resident_logement');
+
+	const residentsMonthly = sumMonthlyArrays([
+		residentSalaires?.monthly_amounts ?? zeroMonths,
+		residentLogement?.monthly_amounts ?? zeroMonths,
+	]);
+	const residentsAnnual = sumAnnuals([
+		residentSalaires?.annual_total ?? '0.0000',
+		residentLogement?.annual_total ?? '0.0000',
+	]);
+
+	rows.push({
+		id: 'residents',
+		label: 'Residents',
+		type: 'parent',
+		monthlyAmounts: residentsMonthly,
+		annualTotal: residentsAnnual,
+	});
+	rows.push({
+		id: 'resident_salaires',
+		label: 'Resident Salaires',
+		type: 'child',
+		parentId: 'residents',
+		monthlyAmounts: residentSalaires?.monthly_amounts ?? zeroMonths,
+		annualTotal: residentSalaires?.annual_total ?? '0.0000',
+	});
+	rows.push({
+		id: 'resident_logement',
+		label: 'Resident Logement',
+		type: 'child',
+		parentId: 'residents',
+		monthlyAmounts: residentLogement?.monthly_amounts ?? zeroMonths,
+		annualTotal: residentLogement?.annual_total ?? '0.0000',
+	});
+
+	// -- Grand Total --
+	const grandTotalMonthly = sumMonthlyArrays([subtotalMonthly, contratsMonthly, residentsMonthly]);
+	const grandTotalAnnual = sumAnnuals([subtotalAnnual, contratsAnnual, residentsAnnual]);
+
+	rows.push({
+		id: 'grand_total',
+		label: 'GRAND TOTAL',
+		type: 'grand-total',
+		monthlyAmounts: grandTotalMonthly,
+		annualTotal: grandTotalAnnual,
+	});
+
+	return rows;
+}
+
+function LoadingSkeleton() {
+	return (
+		<table className="w-full border-collapse text-sm" role="grid" aria-readonly="true">
+			<thead>
+				<tr>
+					<th className="px-3 py-2 text-left">
+						<Skeleton className="h-4 w-24" />
+					</th>
+					{MONTH_LABELS.map((m) => (
+						<th key={m} className="px-3 py-2">
+							<Skeleton className="h-4 w-16" />
+						</th>
+					))}
+					<th className="px-3 py-2">
+						<Skeleton className="h-4 w-20" />
+					</th>
+				</tr>
+			</thead>
+			<tbody>
+				{Array.from({ length: 8 }).map((_, i) => (
+					<tr key={i}>
+						<td className="px-3 py-2">
+							<Skeleton className="h-4 w-32" />
+						</td>
+						{Array.from({ length: 13 }).map((_, j) => (
+							<td key={j} className="px-3 py-2">
+								<Skeleton className="h-4 w-16" />
+							</td>
+						))}
+					</tr>
+				))}
+			</tbody>
+		</table>
+	);
+}
+
+export function MonthlyCostBudgetGrid({
+	staffCostData,
+	categoryCostData,
+	isLoading,
+}: MonthlyCostBudgetGridProps) {
+	const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+
+	const gridRows = useMemo(() => {
+		if (!staffCostData) return [];
+		return buildGridRows(staffCostData, categoryCostData);
+	}, [staffCostData, categoryCostData]);
+
+	if (isLoading) {
+		return <LoadingSkeleton />;
+	}
+
+	if (!staffCostData) {
+		return (
+			<div className="py-6 text-center text-sm text-(--text-muted)">
+				No staff cost data available. Run Calculate to generate monthly costs.
+			</div>
+		);
+	}
+
+	function toggleGroup(groupId: string) {
+		setCollapsedGroups((prev) => {
+			const next = new Set(prev);
+			if (next.has(groupId)) {
+				next.delete(groupId);
+			} else {
+				next.add(groupId);
+			}
+			return next;
+		});
+	}
+
+	const visibleRows = gridRows.filter((row) => {
+		if (!row.parentId) return true;
+		return !collapsedGroups.has(row.parentId);
+	});
+
+	return (
+		<div className="overflow-x-auto rounded-(--radius-md) border border-(--workspace-border)">
+			<table
+				className="w-full border-collapse text-sm"
+				role="grid"
+				aria-readonly="true"
+				aria-label="Monthly Cost Budget"
+			>
+				<thead>
+					<tr className="bg-(--workspace-bg-subtle)">
+						<th className="sticky left-0 z-10 min-w-[200px] bg-(--workspace-bg-subtle) px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-(--text-muted)">
+							Category
+						</th>
+						{MONTH_LABELS.map((label, idx) => (
+							<th
+								key={label}
+								className={cn(
+									'min-w-[110px] px-3 py-2 text-right text-xs font-medium uppercase tracking-wider text-(--text-muted)',
+									idx === 8 && 'bg-(--color-warning-bg)/30'
+								)}
+							>
+								{label}
+							</th>
+						))}
+						<th className="min-w-[130px] px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-(--text-muted)">
+							Annual
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{visibleRows.map((row) => (
+						<tr
+							key={row.id}
+							className={cn(
+								'border-t border-(--workspace-border)',
+								row.type === 'parent' && 'bg-(--workspace-bg-muted)',
+								row.type === 'subtotal' &&
+									'border-t-2 border-(--workspace-border) bg-(--workspace-bg-muted)',
+								row.type === 'grand-total' &&
+									'border-t-2 border-(--workspace-border) bg-(--workspace-bg-muted)'
+							)}
+						>
+							<td
+								className={cn(
+									'sticky left-0 z-10 px-3 py-1.5 text-(--text-primary)',
+									row.type === 'parent' && 'bg-(--workspace-bg-muted) font-semibold',
+									row.type === 'child' && 'bg-(--workspace-bg) pl-9',
+									row.type === 'subtotal' && 'bg-(--workspace-bg-muted) font-bold',
+									row.type === 'grand-total' && 'bg-(--workspace-bg-muted) text-lg font-bold'
+								)}
+							>
+								{row.type === 'parent' ? (
+									<button
+										type="button"
+										className="flex w-full items-center gap-1.5 text-left"
+										onClick={() => toggleGroup(row.id)}
+										aria-expanded={!collapsedGroups.has(row.id)}
+										aria-label={row.label}
+									>
+										<span
+											className={cn(
+												'inline-block text-xs transition-transform',
+												collapsedGroups.has(row.id) && '-rotate-90'
+											)}
+											aria-hidden="true"
+										>
+											&#9660;
+										</span>
+										{row.label}
+									</button>
+								) : (
+									row.label
+								)}
+							</td>
+							{row.monthlyAmounts.map((amount, idx) => (
+								<td
+									key={idx}
+									className={cn(
+										'px-3 py-1.5 text-right font-mono text-(--text-primary)',
+										idx === 8 && 'bg-(--color-warning-bg)/30',
+										row.type === 'subtotal' && 'font-bold',
+										row.type === 'grand-total' && 'font-bold'
+									)}
+								>
+									{formatCurrency(amount)}
+								</td>
+							))}
+							<td
+								className={cn(
+									'px-3 py-1.5 text-right font-mono font-semibold text-(--accent-700)',
+									row.type === 'subtotal' && 'font-bold',
+									row.type === 'grand-total' && 'text-lg font-bold'
+								)}
+							>
+								{formatCurrency(row.annualTotal)}
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}

--- a/apps/web/src/hooks/use-staffing.ts
+++ b/apps/web/src/hooks/use-staffing.ts
@@ -92,6 +92,23 @@ export interface StaffCostResponse {
 	breakdown: StaffCostBreakdown[] | null;
 }
 
+export interface CategoryMonthEntry {
+	key: string;
+	label: string;
+	monthly_amounts: string[];
+	annual_total: string;
+}
+
+export interface CategoryMonthData {
+	months: number[];
+	categories: CategoryMonthEntry[];
+	annual_totals: Record<string, string>;
+}
+
+export interface CategoryCostData {
+	categories: CategoryMonthEntry[];
+}
+
 export interface StaffingSummaryResponse {
 	totalFTE: string;
 	totalSalaryCost: string;


### PR DESCRIPTION
## Summary

- Build `MonthlyCostBudgetGrid` component for Tab C of the Staffing & Staff Costs module
- 12-month columns (Jan-Dec) plus Annual Total column with pinned Category column
- Hierarchical row structure: Local Staff Salaries (expandable), GOSI, Ajeer, EoS Accrual, Subtotal, Contrats Locaux (expandable), Residents (expandable), Grand Total
- All monetary formatting via Decimal.js (TC-001 compliant)
- WCAG AA accessible: `role="grid"`, `aria-readonly="true"`, keyboard-navigable expand/collapse
- Skeleton loading state and empty state handling
- 17 new tests covering all 3 acceptance criteria + edge cases

Fixes #161
Part of Epic #8

## Test plan

- [x] AC-10: Grid renders 12-month columns + Annual Total column
- [x] AC-11: Category hierarchy with expandable parent rows (Local Staff Salaries, Contrats Locaux, Residents)
- [x] AC-12: Grand Total row correctly sums all categories
- [x] Loading skeleton state renders properly
- [x] Empty data state shows appropriate message
- [x] TC-001: Currency values formatted via Decimal.js
- [x] TypeCheck passes (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [x] All 774 tests pass (701 API + 73 web)

Generated with [Claude Code](https://claude.com/claude-code)