### PR TITLE
feat(staffing): page layout, toolbar, stores, and hooks infrastructure (#222)

### DIFF
--- a/apps/web/src/hooks/use-master-data.test.ts
+++ b/apps/web/src/hooks/use-master-data.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import {
+	useServiceProfiles,
+	useDisciplines,
+	useDhgRules,
+	useAutoSuggestAssignments,
+	useDemandOverrides,
+} from './use-master-data';
+
+// Mock apiClient to track calls
+const mockApiClient = vi.fn();
+
+vi.mock('../lib/api-client', () => ({
+	apiClient: (...args: unknown[]) => mockApiClient(...args),
+	ApiError: class ApiError extends Error {
+		status: number;
+		code: string;
+		constructor(status: number, code: string, message: string) {
+			super(message);
+			this.status = status;
+			this.code = code;
+		}
+	},
+}));
+
+vi.mock('../components/ui/toast-state', () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+function createWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(QueryClientProvider, { client: queryClient }, children);
+	};
+}
+
+afterEach(() => {
+	mockApiClient.mockReset();
+});
+
+// ── useServiceProfiles ──────────────────────────────────────────────────────
+
+describe('useServiceProfiles', () => {
+	it('fetches service profiles from master data', async () => {
+		const mockData = {
+			data: [{ id: 1, code: 'CERT', label: 'Certifie', defaultOrs: '18', isHsaEligible: true }],
+		};
+		mockApiClient.mockResolvedValue(mockData);
+
+		const { result } = renderHook(() => useServiceProfiles(), { wrapper: createWrapper() });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/master-data/service-profiles');
+		expect(result.current.data).toEqual(mockData);
+	});
+});
+
+// ── useDisciplines ──────────────────────────────────────────────────────────
+
+describe('useDisciplines', () => {
+	it('fetches disciplines from master data', async () => {
+		const mockData = {
+			data: [{ id: 1, code: 'MATHS', label: 'Mathematics', band: null }],
+		};
+		mockApiClient.mockResolvedValue(mockData);
+
+		const { result } = renderHook(() => useDisciplines(), { wrapper: createWrapper() });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/master-data/disciplines');
+		expect(result.current.data).toEqual(mockData);
+	});
+});
+
+// ── useDhgRules ─────────────────────────────────────────────────────────────
+
+describe('useDhgRules', () => {
+	it('fetches DHG rules from master data', async () => {
+		const mockData = {
+			data: [
+				{
+					id: 1,
+					band: 'COLLEGE',
+					gradeLevel: '6eme',
+					disciplineCode: 'MATHS',
+					hoursPerWeekPerSection: '4.5',
+					dhgType: 'STRUCTURAL',
+				},
+			],
+		};
+		mockApiClient.mockResolvedValue(mockData);
+
+		const { result } = renderHook(() => useDhgRules(), { wrapper: createWrapper() });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/master-data/dhg-rules');
+		expect(result.current.data).toEqual(mockData);
+	});
+});
+
+// ── useAutoSuggestAssignments ───────────────────────────────────────────────
+
+describe('useAutoSuggestAssignments', () => {
+	it('sends POST to auto-suggest endpoint', async () => {
+		const mockData = { data: [] };
+		mockApiClient.mockResolvedValue(mockData);
+
+		const { result } = renderHook(() => useAutoSuggestAssignments(10), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate();
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/staffing-assignments/auto-suggest', {
+			method: 'POST',
+		});
+	});
+});
+
+// ── useDemandOverrides ──────────────────────────────────────────────────────
+
+describe('useDemandOverrides', () => {
+	it('fetches demand overrides', async () => {
+		const mockData = { data: [] };
+		mockApiClient.mockResolvedValue(mockData);
+
+		const { result } = renderHook(() => useDemandOverrides(10), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/demand-overrides');
+	});
+
+	it('does not fetch when versionId is null', () => {
+		renderHook(() => useDemandOverrides(null), { wrapper: createWrapper() });
+		expect(mockApiClient).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/hooks/use-master-data.ts
+++ b/apps/web/src/hooks/use-master-data.ts
@@ -1,0 +1,120 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../lib/api-client';
+import { toast } from '../components/ui/toast-state';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface ServiceProfile {
+	id: number;
+	code: string;
+	label: string;
+	defaultOrs: string;
+	isHsaEligible: boolean;
+}
+
+export interface ServiceProfilesResponse {
+	data: ServiceProfile[];
+}
+
+export interface Discipline {
+	id: number;
+	code: string;
+	label: string;
+	band: string | null;
+}
+
+export interface DisciplinesResponse {
+	data: Discipline[];
+}
+
+export interface DhgRule {
+	id: number;
+	band: string;
+	gradeLevel: string;
+	disciplineCode: string;
+	hoursPerWeekPerSection: string;
+	dhgType: string;
+}
+
+export interface DhgRulesResponse {
+	data: DhgRule[];
+}
+
+export interface AutoSuggestResult {
+	employeeId: number;
+	employeeName: string;
+	requirementLineId: number;
+	band: string;
+	disciplineCode: string;
+	fteShare: string;
+	confidence: 'High' | 'Medium';
+}
+
+export interface AutoSuggestResponse {
+	data: AutoSuggestResult[];
+}
+
+export interface DemandOverride {
+	id: number;
+	requirementLineId: number;
+	overrideType: string;
+	value: string;
+}
+
+export interface DemandOverridesResponse {
+	data: DemandOverride[];
+}
+
+// ── Master Data Hooks ───────────────────────────────────────────────────────
+
+export function useServiceProfiles() {
+	return useQuery({
+		queryKey: ['master-data', 'service-profiles'],
+		queryFn: () => apiClient<ServiceProfilesResponse>('/master-data/service-profiles'),
+	});
+}
+
+export function useDisciplines() {
+	return useQuery({
+		queryKey: ['master-data', 'disciplines'],
+		queryFn: () => apiClient<DisciplinesResponse>('/master-data/disciplines'),
+	});
+}
+
+export function useDhgRules() {
+	return useQuery({
+		queryKey: ['master-data', 'dhg-rules'],
+		queryFn: () => apiClient<DhgRulesResponse>('/master-data/dhg-rules'),
+	});
+}
+
+// ── Version-Scoped Hooks ────────────────────────────────────────────────────
+
+export function useAutoSuggestAssignments(versionId: number | null) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: () =>
+			apiClient<AutoSuggestResponse>(`/versions/${versionId}/staffing-assignments/auto-suggest`, {
+				method: 'POST',
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ['staffing-assignments', versionId],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ['teaching-requirements', versionId],
+			});
+			queryClient.invalidateQueries({ queryKey: ['versions'] });
+			toast.success('Auto-suggest assignments generated');
+		},
+		onError: (err) => toast.error(err instanceof Error ? err.message : 'Auto-suggest failed'),
+	});
+}
+
+export function useDemandOverrides(versionId: number | null) {
+	return useQuery({
+		queryKey: ['demand-overrides', versionId],
+		queryFn: () => apiClient<DemandOverridesResponse>(`/versions/${versionId}/demand-overrides`),
+		enabled: versionId !== null,
+	});
+}

--- a/apps/web/src/hooks/use-staffing-hooks.test.ts
+++ b/apps/web/src/hooks/use-staffing-hooks.test.ts
@@ -1,0 +1,362 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import {
+	useStaffingSettings,
+	usePutStaffingSettings,
+	useServiceProfileOverrides,
+	usePutServiceProfileOverrides,
+	useCostAssumptions,
+	usePutCostAssumptions,
+	useLyceeGroupAssumptions,
+	usePutLyceeGroupAssumptions,
+	useTeachingRequirements,
+	useTeachingRequirementSources,
+	useStaffingAssignments,
+	useCreateAssignment,
+	useUpdateAssignment,
+	useDeleteAssignment,
+} from './use-staffing';
+
+// Mock apiClient to track calls
+const mockApiClient = vi.fn();
+
+vi.mock('../lib/api-client', () => ({
+	apiClient: (...args: unknown[]) => mockApiClient(...args),
+	ApiError: class ApiError extends Error {
+		status: number;
+		code: string;
+		constructor(status: number, code: string, message: string) {
+			super(message);
+			this.status = status;
+			this.code = code;
+		}
+	},
+}));
+
+vi.mock('../components/ui/toast-state', () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+function createWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(QueryClientProvider, { client: queryClient }, children);
+	};
+}
+
+afterEach(() => {
+	mockApiClient.mockReset();
+});
+
+// ── useStaffingSettings ─────────────────────────────────────────────────────
+
+describe('useStaffingSettings', () => {
+	it('fetches staffing settings for the given versionId', async () => {
+		const mockData = { data: { id: 1, versionId: 10, hsaMonths: 10 } };
+		mockApiClient.mockResolvedValue(mockData);
+
+		const { result } = renderHook(() => useStaffingSettings(10), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/staffing-settings');
+		expect(result.current.data).toEqual(mockData);
+	});
+
+	it('does not fetch when versionId is null', () => {
+		renderHook(() => useStaffingSettings(null), { wrapper: createWrapper() });
+		expect(mockApiClient).not.toHaveBeenCalled();
+	});
+});
+
+// ── usePutStaffingSettings ──────────────────────────────────────────────────
+
+describe('usePutStaffingSettings', () => {
+	it('sends PUT to staffing-settings endpoint', async () => {
+		mockApiClient.mockResolvedValue({ data: { id: 1 } });
+
+		const { result } = renderHook(() => usePutStaffingSettings(10), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({ hsaMonths: 10 });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/staffing-settings', {
+			method: 'PUT',
+			body: JSON.stringify({ hsaMonths: 10 }),
+		});
+	});
+});
+
+// ── useServiceProfileOverrides ──────────────────────────────────────────────
+
+describe('useServiceProfileOverrides', () => {
+	it('fetches service profile overrides', async () => {
+		const mockData = { data: [{ serviceProfileId: 1, effectiveOrs: '18' }] };
+		mockApiClient.mockResolvedValue(mockData);
+
+		const { result } = renderHook(() => useServiceProfileOverrides(10), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/service-profile-overrides');
+	});
+
+	it('does not fetch when versionId is null', () => {
+		renderHook(() => useServiceProfileOverrides(null), { wrapper: createWrapper() });
+		expect(mockApiClient).not.toHaveBeenCalled();
+	});
+});
+
+// ── usePutServiceProfileOverrides ───────────────────────────────────────────
+
+describe('usePutServiceProfileOverrides', () => {
+	it('sends PUT with overrides', async () => {
+		mockApiClient.mockResolvedValue({ data: [] });
+
+		const { result } = renderHook(() => usePutServiceProfileOverrides(10), {
+			wrapper: createWrapper(),
+		});
+
+		const overrides = [{ serviceProfileId: 1, effectiveOrs: '18' }];
+		result.current.mutate(overrides);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/service-profile-overrides', {
+			method: 'PUT',
+			body: JSON.stringify({ overrides }),
+		});
+	});
+});
+
+// ── useCostAssumptions ──────────────────────────────────────────────────────
+
+describe('useCostAssumptions', () => {
+	it('fetches cost assumptions', async () => {
+		const mockData = { data: [{ category: 'formation', mode: 'fixed', value: '5000' }] };
+		mockApiClient.mockResolvedValue(mockData);
+
+		const { result } = renderHook(() => useCostAssumptions(10), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/cost-assumptions');
+	});
+
+	it('does not fetch when versionId is null', () => {
+		renderHook(() => useCostAssumptions(null), { wrapper: createWrapper() });
+		expect(mockApiClient).not.toHaveBeenCalled();
+	});
+});
+
+// ── usePutCostAssumptions ───────────────────────────────────────────────────
+
+describe('usePutCostAssumptions', () => {
+	it('sends PUT with assumptions', async () => {
+		mockApiClient.mockResolvedValue({ data: [] });
+
+		const { result } = renderHook(() => usePutCostAssumptions(10), {
+			wrapper: createWrapper(),
+		});
+
+		const assumptions = [{ category: 'formation', mode: 'fixed', value: '5000' }];
+		result.current.mutate(assumptions);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/cost-assumptions', {
+			method: 'PUT',
+			body: JSON.stringify({ assumptions }),
+		});
+	});
+});
+
+// ── useLyceeGroupAssumptions ────────────────────────────────────────────────
+
+describe('useLyceeGroupAssumptions', () => {
+	it('fetches lycee group assumptions', async () => {
+		mockApiClient.mockResolvedValue({ data: [] });
+
+		const { result } = renderHook(() => useLyceeGroupAssumptions(10), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/lycee-group-assumptions');
+	});
+
+	it('does not fetch when versionId is null', () => {
+		renderHook(() => useLyceeGroupAssumptions(null), { wrapper: createWrapper() });
+		expect(mockApiClient).not.toHaveBeenCalled();
+	});
+});
+
+// ── usePutLyceeGroupAssumptions ─────────────────────────────────────────────
+
+describe('usePutLyceeGroupAssumptions', () => {
+	it('sends PUT with assumptions', async () => {
+		mockApiClient.mockResolvedValue({ data: [] });
+
+		const { result } = renderHook(() => usePutLyceeGroupAssumptions(10), {
+			wrapper: createWrapper(),
+		});
+
+		const assumptions = [{ disciplineCode: 'MATHS', groupCount: 3, hoursPerGroup: '2.0' }];
+		result.current.mutate(assumptions);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/lycee-group-assumptions', {
+			method: 'PUT',
+			body: JSON.stringify({ assumptions }),
+		});
+	});
+});
+
+// ── useTeachingRequirements ─────────────────────────────────────────────────
+
+describe('useTeachingRequirements', () => {
+	it('fetches teaching requirements', async () => {
+		const mockData = { data: [], totals: {} };
+		mockApiClient.mockResolvedValue(mockData);
+
+		const { result } = renderHook(() => useTeachingRequirements(10), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/teaching-requirements');
+	});
+
+	it('does not fetch when versionId is null', () => {
+		renderHook(() => useTeachingRequirements(null), { wrapper: createWrapper() });
+		expect(mockApiClient).not.toHaveBeenCalled();
+	});
+});
+
+// ── useTeachingRequirementSources ───────────────────────────────────────────
+
+describe('useTeachingRequirementSources', () => {
+	it('fetches requirement sources for a specific line', async () => {
+		const mockData = { data: [] };
+		mockApiClient.mockResolvedValue(mockData);
+
+		const { result } = renderHook(() => useTeachingRequirementSources(10, 42), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/teaching-requirements/42/sources');
+	});
+
+	it('does not fetch when versionId is null', () => {
+		renderHook(() => useTeachingRequirementSources(null, 42), { wrapper: createWrapper() });
+		expect(mockApiClient).not.toHaveBeenCalled();
+	});
+
+	it('does not fetch when requirementId is null', () => {
+		renderHook(() => useTeachingRequirementSources(10, null), { wrapper: createWrapper() });
+		expect(mockApiClient).not.toHaveBeenCalled();
+	});
+});
+
+// ── useStaffingAssignments ──────────────────────────────────────────────────
+
+describe('useStaffingAssignments', () => {
+	it('fetches staffing assignments', async () => {
+		const mockData = { data: [] };
+		mockApiClient.mockResolvedValue(mockData);
+
+		const { result } = renderHook(() => useStaffingAssignments(10), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/staffing-assignments');
+	});
+
+	it('does not fetch when versionId is null', () => {
+		renderHook(() => useStaffingAssignments(null), { wrapper: createWrapper() });
+		expect(mockApiClient).not.toHaveBeenCalled();
+	});
+});
+
+// ── useCreateAssignment ─────────────────────────────────────────────────────
+
+describe('useCreateAssignment', () => {
+	it('sends POST to create assignment', async () => {
+		mockApiClient.mockResolvedValue({ id: 1 });
+
+		const { result } = renderHook(() => useCreateAssignment(10), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			requirementLineId: 42,
+			employeeId: 99,
+			fteShare: '1.0',
+			hoursPerWeek: '18',
+			note: null,
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/staffing-assignments', {
+			method: 'POST',
+			body: expect.any(String),
+		});
+	});
+});
+
+// ── useUpdateAssignment ─────────────────────────────────────────────────────
+
+describe('useUpdateAssignment', () => {
+	it('sends PUT to update assignment', async () => {
+		mockApiClient.mockResolvedValue({ id: 1 });
+
+		const { result } = renderHook(() => useUpdateAssignment(10), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate({
+			id: 1,
+			data: { fteShare: '0.5' },
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/staffing-assignments/1', {
+			method: 'PUT',
+			body: JSON.stringify({ fteShare: '0.5' }),
+		});
+	});
+});
+
+// ── useDeleteAssignment ─────────────────────────────────────────────────────
+
+describe('useDeleteAssignment', () => {
+	it('sends DELETE to remove assignment', async () => {
+		mockApiClient.mockResolvedValue(undefined);
+
+		const { result } = renderHook(() => useDeleteAssignment(10), {
+			wrapper: createWrapper(),
+		});
+
+		result.current.mutate(1);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(mockApiClient).toHaveBeenCalledWith('/versions/10/staffing-assignments/1', {
+			method: 'DELETE',
+		});
+	});
+});

--- a/apps/web/src/hooks/use-staffing.ts
+++ b/apps/web/src/hooks/use-staffing.ts
@@ -335,3 +335,334 @@ export function useImportEmployees(versionId: number | null) {
 		onError: (err) => toast.error(err instanceof Error ? err.message : 'Import failed'),
 	});
 }
+
+// ── Staffing Settings Hooks ─────────────────────────────────────────────────
+
+export interface StaffingSettings {
+	id: number;
+	versionId: number;
+	hsaTargetHoursPerWeek: string;
+	hsaRateFirstHour: string;
+	hsaRateAdditionalHour: string;
+	hsaMonths: number;
+}
+
+export interface StaffingSettingsResponse {
+	data: StaffingSettings;
+}
+
+export function useStaffingSettings(versionId: number | null) {
+	return useQuery({
+		queryKey: ['staffing-settings', versionId],
+		queryFn: () => apiClient<StaffingSettingsResponse>(`/versions/${versionId}/staffing-settings`),
+		enabled: versionId !== null,
+	});
+}
+
+export function usePutStaffingSettings(versionId: number | null) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (data: Partial<StaffingSettings>) =>
+			apiClient<StaffingSettingsResponse>(`/versions/${versionId}/staffing-settings`, {
+				method: 'PUT',
+				body: JSON.stringify(data),
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ['staffing-settings', versionId],
+			});
+			queryClient.invalidateQueries({ queryKey: ['versions'] });
+			toast.success('Staffing settings saved');
+		},
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : 'Failed to save staffing settings'),
+	});
+}
+
+// ── Service Profile Override Hooks ──────────────────────────────────────────
+
+export interface ServiceProfileOverride {
+	serviceProfileId: number;
+	effectiveOrs: string;
+}
+
+export interface ServiceProfileOverridesResponse {
+	data: ServiceProfileOverride[];
+}
+
+export function useServiceProfileOverrides(versionId: number | null) {
+	return useQuery({
+		queryKey: ['service-profile-overrides', versionId],
+		queryFn: () =>
+			apiClient<ServiceProfileOverridesResponse>(
+				`/versions/${versionId}/service-profile-overrides`
+			),
+		enabled: versionId !== null,
+	});
+}
+
+export function usePutServiceProfileOverrides(versionId: number | null) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (data: ServiceProfileOverride[]) =>
+			apiClient<ServiceProfileOverridesResponse>(
+				`/versions/${versionId}/service-profile-overrides`,
+				{
+					method: 'PUT',
+					body: JSON.stringify({ overrides: data }),
+				}
+			),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ['service-profile-overrides', versionId],
+			});
+			queryClient.invalidateQueries({ queryKey: ['versions'] });
+			toast.success('Service profile overrides saved');
+		},
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : 'Failed to save service profile overrides'),
+	});
+}
+
+// ── Cost Assumptions Hooks ──────────────────────────────────────────────────
+
+export interface CostAssumption {
+	category: string;
+	mode: string;
+	value: string;
+}
+
+export interface CostAssumptionsResponse {
+	data: CostAssumption[];
+}
+
+export function useCostAssumptions(versionId: number | null) {
+	return useQuery({
+		queryKey: ['cost-assumptions', versionId],
+		queryFn: () => apiClient<CostAssumptionsResponse>(`/versions/${versionId}/cost-assumptions`),
+		enabled: versionId !== null,
+	});
+}
+
+export function usePutCostAssumptions(versionId: number | null) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (data: CostAssumption[]) =>
+			apiClient<CostAssumptionsResponse>(`/versions/${versionId}/cost-assumptions`, {
+				method: 'PUT',
+				body: JSON.stringify({ assumptions: data }),
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ['cost-assumptions', versionId],
+			});
+			queryClient.invalidateQueries({ queryKey: ['versions'] });
+			toast.success('Cost assumptions saved');
+		},
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : 'Failed to save cost assumptions'),
+	});
+}
+
+// ── Lycee Group Assumptions Hooks ───────────────────────────────────────────
+
+export interface LyceeGroupAssumption {
+	disciplineCode: string;
+	groupCount: number;
+	hoursPerGroup: string;
+}
+
+export interface LyceeGroupAssumptionsResponse {
+	data: LyceeGroupAssumption[];
+}
+
+export function useLyceeGroupAssumptions(versionId: number | null) {
+	return useQuery({
+		queryKey: ['lycee-group-assumptions', versionId],
+		queryFn: () =>
+			apiClient<LyceeGroupAssumptionsResponse>(`/versions/${versionId}/lycee-group-assumptions`),
+		enabled: versionId !== null,
+	});
+}
+
+export function usePutLyceeGroupAssumptions(versionId: number | null) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (data: LyceeGroupAssumption[]) =>
+			apiClient<LyceeGroupAssumptionsResponse>(`/versions/${versionId}/lycee-group-assumptions`, {
+				method: 'PUT',
+				body: JSON.stringify({ assumptions: data }),
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ['lycee-group-assumptions', versionId],
+			});
+			queryClient.invalidateQueries({ queryKey: ['versions'] });
+			toast.success('Lycee group assumptions saved');
+		},
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : 'Failed to save lycee group assumptions'),
+	});
+}
+
+// ── Teaching Requirements Hooks ─────────────────────────────────────────────
+
+export interface TeachingRequirementLine {
+	id: number;
+	band: string;
+	disciplineCode: string;
+	lineLabel: string;
+	lineType: string;
+	serviceProfileCode: string;
+	totalDriverUnits: number;
+	totalWeeklyHours: string;
+	baseOrs: string;
+	effectiveOrs: string;
+	requiredFteRaw: string;
+	requiredFtePlanned: string;
+	recommendedPositions: number;
+	coveredFte: string;
+	gapFte: string;
+	coverageStatus: string;
+	assignedStaffCount: number;
+	directCostAnnual: string;
+	hsaCostAnnual: string;
+}
+
+export interface TeachingRequirementsResponse {
+	data: TeachingRequirementLine[];
+	totals: {
+		totalFteRaw: string;
+		totalFtePlanned: string;
+		totalFteCovered: string;
+		totalFteGap: string;
+	};
+}
+
+export function useTeachingRequirements(versionId: number | null) {
+	return useQuery({
+		queryKey: ['teaching-requirements', versionId],
+		queryFn: () =>
+			apiClient<TeachingRequirementsResponse>(`/versions/${versionId}/teaching-requirements`),
+		enabled: versionId !== null,
+	});
+}
+
+export interface TeachingRequirementSource {
+	gradeLevel: string;
+	headcount: number;
+	sections: number;
+	hoursPerUnit: string;
+	totalWeeklyHours: string;
+}
+
+export interface TeachingRequirementSourcesResponse {
+	data: TeachingRequirementSource[];
+}
+
+export function useTeachingRequirementSources(
+	versionId: number | null,
+	requirementId: number | null
+) {
+	return useQuery({
+		queryKey: ['teaching-requirement-sources', versionId, requirementId],
+		queryFn: () =>
+			apiClient<TeachingRequirementSourcesResponse>(
+				`/versions/${versionId}/teaching-requirements/${requirementId}/sources`
+			),
+		enabled: versionId !== null && requirementId !== null,
+	});
+}
+
+// ── Staffing Assignment Hooks ───────────────────────────────────────────────
+
+export interface StaffingAssignment {
+	id: number;
+	requirementLineId: number;
+	employeeId: number;
+	fteShare: string;
+	hoursPerWeek: string;
+	note: string | null;
+	source: string;
+}
+
+export interface StaffingAssignmentsResponse {
+	data: StaffingAssignment[];
+}
+
+export function useStaffingAssignments(versionId: number | null) {
+	return useQuery({
+		queryKey: ['staffing-assignments', versionId],
+		queryFn: () =>
+			apiClient<StaffingAssignmentsResponse>(`/versions/${versionId}/staffing-assignments`),
+		enabled: versionId !== null,
+	});
+}
+
+export function useCreateAssignment(versionId: number | null) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (data: Omit<StaffingAssignment, 'id' | 'source'>) =>
+			apiClient<StaffingAssignment>(`/versions/${versionId}/staffing-assignments`, {
+				method: 'POST',
+				body: JSON.stringify(data),
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ['staffing-assignments', versionId],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ['teaching-requirements', versionId],
+			});
+			queryClient.invalidateQueries({ queryKey: ['versions'] });
+			toast.success('Assignment created');
+		},
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : 'Failed to create assignment'),
+	});
+}
+
+export function useUpdateAssignment(versionId: number | null) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: ({ id, data }: { id: number; data: Partial<StaffingAssignment> }) =>
+			apiClient<StaffingAssignment>(`/versions/${versionId}/staffing-assignments/${id}`, {
+				method: 'PUT',
+				body: JSON.stringify(data),
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ['staffing-assignments', versionId],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ['teaching-requirements', versionId],
+			});
+			queryClient.invalidateQueries({ queryKey: ['versions'] });
+			toast.success('Assignment updated');
+		},
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : 'Failed to update assignment'),
+	});
+}
+
+export function useDeleteAssignment(versionId: number | null) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (id: number) =>
+			apiClient(`/versions/${versionId}/staffing-assignments/${id}`, {
+				method: 'DELETE',
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ['staffing-assignments', versionId],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ['teaching-requirements', versionId],
+			});
+			queryClient.invalidateQueries({ queryKey: ['versions'] });
+			toast.success('Assignment deleted');
+		},
+		onError: (err) =>
+			toast.error(err instanceof Error ? err.message : 'Failed to delete assignment'),
+	});
+}

--- a/apps/web/src/lib/staffing-workspace.ts
+++ b/apps/web/src/lib/staffing-workspace.ts
@@ -1,0 +1,43 @@
+// ── Staffing Workspace Types & Utilities ────────────────────────────────────
+
+export type WorkspaceMode = 'teaching' | 'support';
+export type BandFilter = 'ALL' | 'MAT' | 'ELEM' | 'COL' | 'LYC';
+export type CoverageFilter = 'ALL' | 'DEFICIT' | 'SURPLUS' | 'UNCOVERED' | 'COVERED';
+export type ViewPreset = 'Need' | 'Coverage' | 'Cost' | 'Full View';
+
+export type StaffingEditability = 'editable' | 'locked' | 'viewer';
+
+export function deriveStaffingEditability({
+	role,
+	versionStatus,
+}: {
+	role?: string | null;
+	versionStatus?: string | null;
+}): StaffingEditability {
+	if (role === 'Viewer') return 'viewer';
+	if (versionStatus !== 'Draft') return 'locked';
+	return 'editable';
+}
+
+export const BAND_FILTERS: Array<{ value: BandFilter; label: string }> = [
+	{ value: 'ALL', label: 'All' },
+	{ value: 'MAT', label: 'Mat' },
+	{ value: 'ELEM', label: 'Elem' },
+	{ value: 'COL', label: 'Col' },
+	{ value: 'LYC', label: 'Lyc' },
+];
+
+export const VIEW_PRESETS: Array<{ value: ViewPreset; label: string }> = [
+	{ value: 'Need', label: 'Need' },
+	{ value: 'Coverage', label: 'Coverage' },
+	{ value: 'Cost', label: 'Cost' },
+	{ value: 'Full View', label: 'Full View' },
+];
+
+export const COVERAGE_OPTIONS: Array<{ value: CoverageFilter; label: string }> = [
+	{ value: 'ALL', label: 'All Coverage' },
+	{ value: 'DEFICIT', label: 'Deficit' },
+	{ value: 'SURPLUS', label: 'Surplus' },
+	{ value: 'UNCOVERED', label: 'Uncovered' },
+	{ value: 'COVERED', label: 'Covered' },
+];

--- a/apps/web/src/pages/planning/staffing.test.tsx
+++ b/apps/web/src/pages/planning/staffing.test.tsx
@@ -1,0 +1,351 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { StaffingPage } from './staffing';
+
+const mockSetActivePage = vi.fn();
+const mockClearSelection = vi.fn();
+const mockOpenSettings = vi.fn();
+
+let mockWorkspaceContext = {
+	versionId: 20 as number | null,
+	fiscalYear: 2026,
+	versionStatus: 'Draft',
+	versionName: 'v2',
+	versionDataSource: 'MANUAL',
+};
+
+let mockUserRole = 'Admin';
+
+let mockVersionsData = {
+	data: [
+		{
+			id: 20,
+			status: 'Draft',
+			dataSource: 'MANUAL',
+			staleModules: [] as string[],
+			name: 'v2',
+			lastCalculatedAt: '2026-03-17T10:00:00Z',
+		},
+	],
+};
+
+vi.mock('../../hooks/use-workspace-context', () => ({
+	useWorkspaceContext: () => mockWorkspaceContext,
+}));
+
+vi.mock('../../stores/auth-store', () => ({
+	useAuthStore: (selector: (state: { user: { role: string } }) => unknown) =>
+		selector({ user: { role: mockUserRole } }),
+}));
+
+vi.mock('../../stores/right-panel-store', () => ({
+	useRightPanelStore: (
+		selector: (state: { setActivePage: typeof mockSetActivePage; isOpen: boolean }) => unknown
+	) => selector({ setActivePage: mockSetActivePage, isOpen: false }),
+}));
+
+vi.mock('../../stores/staffing-selection-store', () => ({
+	useStaffingSelectionStore: (
+		selector: (state: { clearSelection: typeof mockClearSelection }) => unknown
+	) => selector({ clearSelection: mockClearSelection }),
+}));
+
+vi.mock('../../stores/staffing-settings-store', () => ({
+	useStaffingSettingsSheetStore: (
+		selector: (state: {
+			open: typeof mockOpenSettings;
+			isOpen: boolean;
+			setOpen: (open: boolean) => void;
+		}) => unknown
+	) =>
+		selector({
+			open: mockOpenSettings,
+			isOpen: false,
+			setOpen: vi.fn(),
+		}),
+}));
+
+vi.mock('../../hooks/use-staffing', () => ({
+	useCalculateStaffing: () => ({
+		mutate: vi.fn(),
+		isPending: false,
+		isSuccess: false,
+		isError: false,
+	}),
+}));
+
+vi.mock('../../hooks/use-versions', () => ({
+	useVersions: () => ({
+		data: mockVersionsData,
+	}),
+}));
+
+vi.mock('../../components/ui/button', () => ({
+	Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+		<button type="button" {...props}>
+			{children}
+		</button>
+	),
+}));
+
+// Mock ToggleGroup that calls onValueChange when a ToggleGroupItem is clicked
+let capturedOnValueChange: ((value: string) => void) | undefined;
+
+vi.mock('../../components/ui/toggle-group', () => ({
+	ToggleGroup: ({
+		children,
+		'aria-label': ariaLabel,
+		onValueChange,
+	}: {
+		children: ReactNode;
+		'aria-label'?: string;
+		onValueChange?: (value: string) => void;
+	}) => {
+		// Capture the first ToggleGroup's onValueChange (Workspace mode)
+		if (ariaLabel === 'Workspace mode') {
+			capturedOnValueChange = onValueChange;
+		}
+		return (
+			<div role="group" aria-label={ariaLabel}>
+				{children}
+			</div>
+		);
+	},
+	ToggleGroupItem: ({ children, value }: { children: ReactNode; value: string }) => (
+		<button type="button" data-value={value} onClick={() => capturedOnValueChange?.(value)}>
+			{children}
+		</button>
+	),
+}));
+
+vi.mock('../../components/ui/dropdown-menu', () => ({
+	DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	DropdownMenuTrigger: ({ children }: { children: ReactNode; asChild?: boolean }) => (
+		<div>{children}</div>
+	),
+	DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	DropdownMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../../components/shared/page-transition', () => ({
+	PageTransition: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+describe('StaffingPage', () => {
+	beforeEach(() => {
+		mockSetActivePage.mockClear();
+		mockClearSelection.mockClear();
+		mockOpenSettings.mockClear();
+		capturedOnValueChange = undefined;
+		mockWorkspaceContext = {
+			versionId: 20,
+			fiscalYear: 2026,
+			versionStatus: 'Draft',
+			versionName: 'v2',
+			versionDataSource: 'MANUAL',
+		};
+		mockUserRole = 'Admin';
+		mockVersionsData = {
+			data: [
+				{
+					id: 20,
+					status: 'Draft',
+					dataSource: 'MANUAL',
+					staleModules: [],
+					name: 'v2',
+					lastCalculatedAt: '2026-03-17T10:00:00Z',
+				},
+			],
+		};
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	// AC-01: Page layout
+	it('renders select-version message when no versionId', () => {
+		mockWorkspaceContext = { ...mockWorkspaceContext, versionId: null };
+		render(<StaffingPage />);
+		expect(
+			screen.getByText('Select a version from the context bar to begin staffing planning.')
+		).toBeTruthy();
+	});
+
+	it('renders the fixed-viewport layout container', () => {
+		const { container } = render(<StaffingPage />);
+		const layoutDiv = container.querySelector('.flex.h-full.min-h-0.flex-col.overflow-hidden');
+		expect(layoutDiv).toBeTruthy();
+	});
+
+	it('renders grid zone with correct CSS structure', () => {
+		const { container } = render(<StaffingPage />);
+		const gridZone = container.querySelector('.flex-1.min-h-0.overflow-hidden.px-6.py-2');
+		expect(gridZone).toBeTruthy();
+		const scrollContainer = gridZone?.querySelector('.h-full.overflow-y-auto.scrollbar-thin');
+		expect(scrollContainer).toBeTruthy();
+	});
+
+	it('renders locked banner when version is locked', () => {
+		mockWorkspaceContext = { ...mockWorkspaceContext, versionStatus: 'Locked' };
+		mockVersionsData = {
+			data: [
+				{
+					id: 20,
+					status: 'Locked',
+					dataSource: 'MANUAL',
+					staleModules: [],
+					name: 'v2',
+					lastCalculatedAt: '2026-03-17T10:00:00Z',
+				},
+			],
+		};
+		render(<StaffingPage />);
+		expect(screen.getByText('This version is locked. Staffing data is read-only.')).toBeTruthy();
+	});
+
+	it('renders viewer banner when user role is Viewer', () => {
+		mockUserRole = 'Viewer';
+		render(<StaffingPage />);
+		expect(screen.getByText('You have view-only access.')).toBeTruthy();
+	});
+
+	it('renders uncalculated banner when version has no lastCalculatedAt', () => {
+		mockVersionsData = {
+			data: [
+				{
+					id: 20,
+					status: 'Draft',
+					dataSource: 'MANUAL',
+					staleModules: [],
+					name: 'v2',
+					lastCalculatedAt: null as unknown as string,
+				},
+			],
+		};
+		render(<StaffingPage />);
+		expect(
+			screen.getByText('Staffing has not been calculated. Click Calculate to generate.')
+		).toBeTruthy();
+	});
+
+	// AC-02: Toolbar
+	it('renders workspace mode toggle with Teaching and Support & Admin options', () => {
+		render(<StaffingPage />);
+		expect(screen.getByText('Teaching')).toBeTruthy();
+		expect(screen.getByText('Support & Admin')).toBeTruthy();
+	});
+
+	it('renders band filter in Teaching mode', () => {
+		render(<StaffingPage />);
+		expect(screen.getByRole('group', { name: 'Band filter' })).toBeTruthy();
+	});
+
+	it('renders view presets in Teaching mode', () => {
+		render(<StaffingPage />);
+		expect(screen.getByRole('group', { name: 'View preset' })).toBeTruthy();
+		expect(screen.getByText('Need')).toBeTruthy();
+		expect(screen.getByText('Coverage')).toBeTruthy();
+		expect(screen.getByText('Cost')).toBeTruthy();
+		expect(screen.getByText('Full View')).toBeTruthy();
+	});
+
+	it('renders coverage filter in Teaching mode with non-Need preset', () => {
+		render(<StaffingPage />);
+		// Default viewPreset is 'Full View', so coverage filter should be visible.
+		// 'All Coverage' appears both in trigger button and menu item, so use getAllByText.
+		const allCoverageElements = screen.getAllByText('All Coverage');
+		expect(allCoverageElements.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('renders Settings button always', () => {
+		render(<StaffingPage />);
+		expect(screen.getByText('Settings')).toBeTruthy();
+	});
+
+	it('renders Calculate, Import, Add Employee buttons when editable', () => {
+		render(<StaffingPage />);
+		expect(screen.getByText('Calculate')).toBeTruthy();
+		expect(screen.getByText('Import')).toBeTruthy();
+		expect(screen.getByText('Add Employee')).toBeTruthy();
+	});
+
+	it('renders Auto-Suggest in Teaching mode when editable', () => {
+		render(<StaffingPage />);
+		expect(screen.getByText('Auto-Suggest')).toBeTruthy();
+	});
+
+	it('hides Calculate, Import, Add Employee, Auto-Suggest when viewer', () => {
+		mockUserRole = 'Viewer';
+		render(<StaffingPage />);
+		expect(screen.queryByText('Calculate')).toBeNull();
+		expect(screen.queryByText('Import')).toBeNull();
+		expect(screen.queryByText('Add Employee')).toBeNull();
+		expect(screen.queryByText('Auto-Suggest')).toBeNull();
+	});
+
+	it('hides editable buttons when version is locked', () => {
+		mockWorkspaceContext = { ...mockWorkspaceContext, versionStatus: 'Locked' };
+		mockVersionsData = {
+			data: [
+				{
+					id: 20,
+					status: 'Locked',
+					dataSource: 'MANUAL',
+					staleModules: [],
+					name: 'v2',
+					lastCalculatedAt: '2026-03-17T10:00:00Z',
+				},
+			],
+		};
+		render(<StaffingPage />);
+		expect(screen.queryByText('Calculate')).toBeNull();
+		expect(screen.queryByText('Import')).toBeNull();
+		expect(screen.queryByText('Add Employee')).toBeNull();
+		expect(screen.queryByText('Auto-Suggest')).toBeNull();
+	});
+
+	it('hides band filter, coverage filter, and view presets in Support mode', () => {
+		render(<StaffingPage />);
+		// Default is Teaching mode — verify they exist first
+		expect(screen.getByRole('group', { name: 'Band filter' })).toBeTruthy();
+
+		// Switch to Support mode by clicking the Support & Admin button
+		const supportButton = screen.getByText('Support & Admin');
+		fireEvent.click(supportButton);
+
+		// After switching, band filter should not be in the DOM
+		expect(screen.queryByRole('group', { name: 'Band filter' })).toBeNull();
+		expect(screen.queryByRole('group', { name: 'View preset' })).toBeNull();
+	});
+
+	it('hides Auto-Suggest in Support mode even when editable', () => {
+		render(<StaffingPage />);
+		expect(screen.getByText('Auto-Suggest')).toBeTruthy();
+
+		// Switch to Support mode
+		const supportButton = screen.getByText('Support & Admin');
+		fireEvent.click(supportButton);
+
+		expect(screen.queryByText('Auto-Suggest')).toBeNull();
+	});
+
+	it('shows Teaching workspace placeholder in teaching mode', () => {
+		render(<StaffingPage />);
+		expect(screen.getByText('Teaching workspace')).toBeTruthy();
+	});
+
+	it('shows Support & Admin workspace placeholder in support mode', () => {
+		render(<StaffingPage />);
+		const supportButton = screen.getByText('Support & Admin');
+		fireEvent.click(supportButton);
+		expect(screen.getByText('Support & Admin workspace')).toBeTruthy();
+	});
+
+	it('Settings button is visible even when viewer', () => {
+		mockUserRole = 'Viewer';
+		render(<StaffingPage />);
+		expect(screen.getByText('Settings')).toBeTruthy();
+	});
+});

--- a/apps/web/src/pages/planning/staffing.tsx
+++ b/apps/web/src/pages/planning/staffing.tsx
@@ -1,136 +1,89 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useWorkspaceContext } from '../../hooks/use-workspace-context';
 import { useAuthStore } from '../../stores/auth-store';
-import {
-	useEmployees,
-	useCreateEmployee,
-	useUpdateEmployee,
-	useDeleteEmployee,
-	useCalculateStaffing,
-	useDhgData,
-	useStaffCosts,
-	useStaffingSummary,
-	type Employee,
-} from '../../hooks/use-staffing';
+import { useRightPanelStore } from '../../stores/right-panel-store';
+import { useStaffingSelectionStore } from '../../stores/staffing-selection-store';
+import { useStaffingSettingsSheetStore } from '../../stores/staffing-settings-store';
+import { useCalculateStaffing } from '../../hooks/use-staffing';
 import { useVersions } from '../../hooks/use-versions';
-import { WorkspaceBoard } from '../../components/shared/workspace-board';
-import { WorkspaceBlock } from '../../components/shared/workspace-block';
-import { StaffingKpiRibbon } from '../../components/staffing/kpi-ribbon';
-import { EmployeeGrid } from '../../components/staffing/employee-grid';
-import { EmployeeForm, type EmployeeFormData } from '../../components/staffing/employee-form';
-import { EmployeeImportDialog } from '../../components/staffing/employee-import-dialog';
-import { DhgGrilleView, DhgRequirementsView } from '../../components/staffing/dhg-view';
-import { MonthlyCostGrid } from '../../components/staffing/monthly-cost-grid';
+import {
+	BAND_FILTERS,
+	COVERAGE_OPTIONS,
+	VIEW_PRESETS,
+	deriveStaffingEditability,
+	type BandFilter,
+	type CoverageFilter,
+	type ViewPreset,
+	type WorkspaceMode,
+} from '../../lib/staffing-workspace';
 import { Button } from '../../components/ui/button';
+import { ToggleGroup, ToggleGroupItem } from '../../components/ui/toggle-group';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from '../../components/ui/dropdown-menu';
 import { PageTransition } from '../../components/shared/page-transition';
 
 export function StaffingPage() {
-	const { versionId, fiscalYear } = useWorkspaceContext();
-	const user = useAuthStore((s) => s.user);
-	const isViewer = user?.role === 'Viewer';
+	const { versionId, fiscalYear, versionStatus } = useWorkspaceContext();
+	const user = useAuthStore((state) => state.user);
+	const setActivePage = useRightPanelStore((state) => state.setActivePage);
+	const isPanelOpen = useRightPanelStore((state) => state.isOpen);
+	const clearSelection = useStaffingSelectionStore((state) => state.clearSelection);
+	const openSettings = useStaffingSettingsSheetStore((state) => state.open);
 
-	const [selectedEmployee, setSelectedEmployee] = useState<Employee | null>(null);
-	const [formOpen, setFormOpen] = useState(false);
-	const [importOpen, setImportOpen] = useState(false);
-	const costGroupBy: 'month' | 'department' | 'employee' = 'month';
+	const [workspaceMode, setWorkspaceMode] = useState<WorkspaceMode>('teaching');
+	const [bandFilter, setBandFilter] = useState<BandFilter>('ALL');
+	const [coverageFilter, setCoverageFilter] = useState<CoverageFilter>('ALL');
+	const [viewPreset, setViewPreset] = useState<ViewPreset>('Full View');
 
-	// Data hooks
-	const { data: employeesData } = useEmployees(versionId);
-	const { data: dhgData } = useDhgData(versionId);
-	const { data: costData } = useStaffCosts(versionId, costGroupBy);
-	const { data: breakdownData, isLoading: isBreakdownLoading } = useStaffCosts(
-		versionId,
-		'employee',
-		true
-	);
-	const { data: summaryData, isLoading: isSummaryLoading } = useStaffingSummary(versionId);
 	const { data: versionsData } = useVersions(fiscalYear);
-
-	// Mutations
 	const calculateMutation = useCalculateStaffing(versionId);
-	const createMutation = useCreateEmployee(versionId);
-	const updateMutation = useUpdateEmployee(versionId);
-	const deleteMutation = useDeleteEmployee(versionId);
+
+	// Register right panel page key
+	useEffect(() => {
+		setActivePage('staffing');
+		return () => {
+			setActivePage(null);
+			clearSelection();
+		};
+	}, [clearSelection, setActivePage]);
+
+	// Clear selection when panel closes
+	useEffect(() => {
+		if (!isPanelOpen) {
+			clearSelection();
+		}
+	}, [clearSelection, isPanelOpen]);
 
 	const currentVersion = useMemo(() => {
 		if (!versionId || !versionsData?.data) return null;
-		return versionsData.data.find((v) => v.id === versionId) ?? null;
+		return versionsData.data.find((version) => version.id === versionId) ?? null;
 	}, [versionId, versionsData]);
 
+	const editability = deriveStaffingEditability({
+		role: user?.role ?? null,
+		versionStatus: currentVersion?.status ?? versionStatus,
+	});
+	const isEditable = editability === 'editable';
+	const isLocked = editability === 'locked';
+	const isViewer = editability === 'viewer';
 	const isStale = currentVersion?.staleModules?.includes('STAFFING') ?? false;
-	const employees = useMemo(() => employeesData?.data ?? [], [employeesData?.data]);
+	const isUncalculated = !isStale && !currentVersion?.lastCalculatedAt;
 
-	const kpiData = useMemo(() => {
-		const activeEmployees = employees.filter((e) => e.status !== 'Departed');
-		const totalHeadcount = activeEmployees.length;
-		const totalAnnualStaffCost = Number(summaryData?.cost ?? 0);
-		const avgMonthlyCostPerEmployee =
-			totalHeadcount > 0 ? Math.round(totalAnnualStaffCost / totalHeadcount / 12) : 0;
-
-		// Sum GOSI, Ajeer, EoS from breakdown rows (API-provided values)
-		const breakdown = breakdownData?.breakdown ?? [];
-		let gosiTotal = 0;
-		let ajeerTotal = 0;
-		let eosTotal = 0;
-		for (const row of breakdown) {
-			gosiTotal += Number(row.gosi_amount);
-			ajeerTotal += Number(row.ajeer_amount);
-			eosTotal += Number(row.eos_monthly_accrual);
+	// Reset filters when workspace mode changes
+	const handleWorkspaceModeChange = (value: string) => {
+		if (value === 'teaching' || value === 'support') {
+			setWorkspaceMode(value);
+			setBandFilter('ALL');
+			setCoverageFilter('ALL');
 		}
+	};
 
-		return {
-			totalHeadcount,
-			totalAnnualStaffCost,
-			avgMonthlyCostPerEmployee,
-			gosiTotal: Math.round(gosiTotal),
-			ajeerTotal: Math.round(ajeerTotal),
-			eosTotal: Math.round(eosTotal),
-			isStale,
-			isLoading: isSummaryLoading || isBreakdownLoading,
-		};
-	}, [summaryData, breakdownData, employees, isStale, isSummaryLoading, isBreakdownLoading]);
-
-	const handleSelectEmployee = useCallback((emp: Employee) => {
-		setSelectedEmployee(emp);
-		setFormOpen(true);
-	}, []);
-
-	const handleNewEmployee = useCallback(() => {
-		setSelectedEmployee(null);
-		setFormOpen(true);
-	}, []);
-
-	const handleSave = useCallback(
-		(data: EmployeeFormData) => {
-			if (selectedEmployee) {
-				updateMutation.mutate(
-					{
-						id: selectedEmployee.id,
-						data: data as unknown as Partial<Employee>,
-						updatedAt: selectedEmployee.updatedAt,
-					},
-					{
-						onSuccess: () => setFormOpen(false),
-					}
-				);
-			} else {
-				createMutation.mutate(data as unknown as Partial<Employee>, {
-					onSuccess: () => setFormOpen(false),
-				});
-			}
-		},
-		[selectedEmployee, updateMutation, createMutation]
-	);
-
-	const handleDelete = useCallback(() => {
-		if (!selectedEmployee) return;
-		deleteMutation.mutate(selectedEmployee.id, {
-			onSuccess: () => {
-				setFormOpen(false);
-				setSelectedEmployee(null);
-			},
-		});
-	}, [selectedEmployee, deleteMutation]);
+	const isTeachingMode = workspaceMode === 'teaching';
+	const showCoverageFilter = isTeachingMode && viewPreset !== 'Need';
 
 	if (!versionId) {
 		return (
@@ -142,102 +95,163 @@ export function StaffingPage() {
 
 	return (
 		<PageTransition>
-			<WorkspaceBoard
-				title="Staffing & Staff Costs"
-				description="Manage employees, DHG requirements, and cost projections."
-				actions={
-					<>
-						{!isViewer && (
-							<>
-								<Button
-									size="sm"
-									disabled={calculateMutation.isPending}
-									onClick={() => calculateMutation.mutate()}
-								>
-									{calculateMutation.isPending ? 'Calculating...' : 'Calculate'}
-								</Button>
-								<Button variant="outline" size="sm" onClick={() => setImportOpen(true)}>
-									Import xlsx
-								</Button>
-								<Button variant="outline" size="sm" onClick={handleNewEmployee}>
-									Add Employee
-								</Button>
-							</>
+			<div className="flex h-full min-h-0 flex-col overflow-hidden">
+				{/* Conditional banners */}
+				{isLocked && versionStatus && (
+					<div className="shrink-0 border-b border-(--color-info) bg-(--color-info-bg) px-4 py-3">
+						<p className="text-sm font-semibold text-(--color-info)">
+							This version is locked. Staffing data is read-only.
+						</p>
+					</div>
+				)}
+				{isViewer && (
+					<div className="shrink-0 border-b border-(--color-info) bg-(--color-info-bg) px-4 py-3">
+						<p className="text-sm font-semibold text-(--color-info)">You have view-only access.</p>
+					</div>
+				)}
+				{isUncalculated && (
+					<div className="shrink-0 border-b border-(--color-warning) bg-(--color-warning-bg) px-4 py-3">
+						<p className="text-sm font-semibold text-(--color-warning)">
+							Staffing has not been calculated. Click Calculate to generate.
+						</p>
+					</div>
+				)}
+
+				{/* Toolbar */}
+				<div className="flex shrink-0 items-center justify-between border-b border-(--workspace-border) px-6 py-2">
+					<div className="flex items-center gap-2">
+						{/* Workspace mode toggle */}
+						<ToggleGroup
+							type="single"
+							value={workspaceMode}
+							onValueChange={handleWorkspaceModeChange}
+							aria-label="Workspace mode"
+						>
+							<ToggleGroupItem value="teaching">Teaching</ToggleGroupItem>
+							<ToggleGroupItem value="support">Support &amp; Admin</ToggleGroupItem>
+						</ToggleGroup>
+
+						{/* Band filter — Teaching mode only */}
+						{isTeachingMode && (
+							<ToggleGroup
+								type="single"
+								value={bandFilter}
+								onValueChange={(value) => {
+									if (value) setBandFilter(value as BandFilter);
+								}}
+								aria-label="Band filter"
+							>
+								{BAND_FILTERS.map((filter) => (
+									<ToggleGroupItem key={filter.value} value={filter.value}>
+										{filter.label}
+									</ToggleGroupItem>
+								))}
+							</ToggleGroup>
 						)}
-					</>
-				}
-				kpiRibbon={<StaffingKpiRibbon {...kpiData} />}
-			>
-				{/* Status feedback */}
-				{calculateMutation.isSuccess && (
-					<div
-						className="rounded-lg border border-(--color-success) bg-(--color-success-bg) px-4 py-2 text-sm text-(--color-success)"
-						role="status"
-					>
-						Staffing calculated successfully.
+
+						{/* Coverage filter — Teaching mode only, hidden when Need */}
+						{showCoverageFilter && (
+							<DropdownMenu>
+								<DropdownMenuTrigger asChild>
+									<Button variant="outline" size="sm">
+										{COVERAGE_OPTIONS.find((opt) => opt.value === coverageFilter)?.label ??
+											'All Coverage'}
+									</Button>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent>
+									{COVERAGE_OPTIONS.map((option) => (
+										<DropdownMenuItem
+											key={option.value}
+											onClick={() => setCoverageFilter(option.value)}
+										>
+											{option.label}
+										</DropdownMenuItem>
+									))}
+								</DropdownMenuContent>
+							</DropdownMenu>
+						)}
 					</div>
-				)}
-				{calculateMutation.isError && (
-					<div
-						className="rounded-lg border border-(--color-error) bg-(--color-error-bg) px-4 py-2 text-sm text-(--color-error)"
-						role="alert"
-					>
-						Calculation failed. Ensure enrollment and employee data are configured.
+
+					<div className="flex items-center gap-2">
+						{/* View presets — Teaching mode only */}
+						{isTeachingMode && (
+							<ToggleGroup
+								type="single"
+								value={viewPreset}
+								onValueChange={(value) => {
+									if (value) setViewPreset(value as ViewPreset);
+								}}
+								aria-label="View preset"
+							>
+								{VIEW_PRESETS.map((preset) => (
+									<ToggleGroupItem key={preset.value} value={preset.value}>
+										{preset.label}
+									</ToggleGroupItem>
+								))}
+							</ToggleGroup>
+						)}
+
+						{/* Settings — always visible */}
+						<Button type="button" variant="outline" size="sm" onClick={openSettings}>
+							Settings
+						</Button>
+
+						{/* Import — editable only */}
+						{isEditable && (
+							<Button type="button" variant="outline" size="sm">
+								Import
+							</Button>
+						)}
+
+						{/* Add Employee — editable only */}
+						{isEditable && (
+							<Button type="button" variant="outline" size="sm">
+								Add Employee
+							</Button>
+						)}
+
+						{/* Auto-Suggest — Teaching mode + editable only */}
+						{isTeachingMode && isEditable && (
+							<Button type="button" variant="outline" size="sm">
+								Auto-Suggest
+							</Button>
+						)}
+
+						{/* Calculate — editable only */}
+						{isEditable && (
+							<Button
+								type="button"
+								size="sm"
+								disabled={calculateMutation.isPending}
+								onClick={() => calculateMutation.mutate()}
+							>
+								{calculateMutation.isPending ? 'Calculating...' : 'Calculate'}
+							</Button>
+						)}
 					</div>
-				)}
+				</div>
 
-				<WorkspaceBlock title="Employee Roster" count={employees.length} isStale={isStale}>
-					<EmployeeGrid
-						employees={employees}
-						isReadOnly={isViewer}
-						onSelect={handleSelectEmployee}
-						selectedId={selectedEmployee?.id ?? null}
-					/>
-				</WorkspaceBlock>
-
-				<WorkspaceBlock title="DHG Requirements" count={dhgData?.requirements?.length ?? 0}>
-					<DhgRequirementsView requirements={dhgData?.requirements ?? []} />
-				</WorkspaceBlock>
-
-				<WorkspaceBlock
-					title="DHG Grille Configuration"
-					count={dhgData?.grilles?.length ?? 0}
-					defaultOpen={false}
-				>
-					<DhgGrilleView grilles={dhgData?.grilles ?? []} />
-				</WorkspaceBlock>
-
-				<WorkspaceBlock title="Monthly Cost Budget">
-					<MonthlyCostGrid
-						data={costData?.data ?? []}
-						totals={costData?.totals ?? null}
-						isRedacted={isViewer}
-					/>
-				</WorkspaceBlock>
-
-				{/* Employee Form Panel */}
-				<EmployeeForm
-					open={formOpen}
-					onClose={() => {
-						setFormOpen(false);
-						setSelectedEmployee(null);
-					}}
-					employee={selectedEmployee}
-					isReadOnly={isViewer}
-					onSave={handleSave}
-					onDelete={handleDelete}
-					isPending={
-						createMutation.isPending || updateMutation.isPending || deleteMutation.isPending
-					}
-				/>
-
-				{/* Import Dialog */}
-				<EmployeeImportDialog
-					open={importOpen}
-					onClose={() => setImportOpen(false)}
-					versionId={versionId}
-				/>
-			</WorkspaceBoard>
+				{/* Grid zone — flex-1, owns its own scroll */}
+				<div className="flex-1 min-h-0 overflow-hidden px-6 py-2">
+					<div className="h-full overflow-y-auto scrollbar-thin">
+						{isTeachingMode ? (
+							<div
+								data-testid="teaching-grid-placeholder"
+								className="flex h-full items-center justify-center text-(--text-muted)"
+							>
+								Teaching workspace
+							</div>
+						) : (
+							<div
+								data-testid="support-grid-placeholder"
+								className="flex h-full items-center justify-center text-(--text-muted)"
+							>
+								Support &amp; Admin workspace
+							</div>
+						)}
+					</div>
+				</div>
+			</div>
 		</PageTransition>
 	);
 }

--- a/apps/web/src/stores/staffing-selection-store.test.ts
+++ b/apps/web/src/stores/staffing-selection-store.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useStaffingSelectionStore } from './staffing-selection-store';
+import { useRightPanelStore } from './right-panel-store';
+
+describe('useStaffingSelectionStore', () => {
+	beforeEach(() => {
+		useStaffingSelectionStore.getState().clearSelection();
+		useRightPanelStore.getState().close();
+	});
+
+	afterEach(() => {
+		useStaffingSelectionStore.getState().clearSelection();
+		useRightPanelStore.getState().close();
+	});
+
+	it('starts with null selection', () => {
+		expect(useStaffingSelectionStore.getState().selection).toBeNull();
+	});
+
+	it('selectRequirementLine sets selection with type REQUIREMENT_LINE and opens panel', () => {
+		useStaffingSelectionStore.getState().selectRequirementLine(42, 'COLLEGE', 'MATHS');
+
+		const selection = useStaffingSelectionStore.getState().selection;
+		expect(selection).toEqual({
+			type: 'REQUIREMENT_LINE',
+			requirementLineId: 42,
+			band: 'COLLEGE',
+			disciplineCode: 'MATHS',
+		});
+		expect(useRightPanelStore.getState().isOpen).toBe(true);
+		expect(useRightPanelStore.getState().activeTab).toBe('details');
+	});
+
+	it('selectSupportEmployee sets selection with type SUPPORT_EMPLOYEE and opens panel', () => {
+		useStaffingSelectionStore.getState().selectSupportEmployee(99, 'Administration');
+
+		const selection = useStaffingSelectionStore.getState().selection;
+		expect(selection).toEqual({
+			type: 'SUPPORT_EMPLOYEE',
+			employeeId: 99,
+			department: 'Administration',
+		});
+		expect(useRightPanelStore.getState().isOpen).toBe(true);
+		expect(useRightPanelStore.getState().activeTab).toBe('details');
+	});
+
+	it('toggling same requirement line deselects and closes panel', () => {
+		useStaffingSelectionStore.getState().selectRequirementLine(42, 'COLLEGE', 'MATHS');
+		expect(useStaffingSelectionStore.getState().selection).not.toBeNull();
+		expect(useRightPanelStore.getState().isOpen).toBe(true);
+
+		// Select the same requirement line again -> deselect
+		useStaffingSelectionStore.getState().selectRequirementLine(42, 'COLLEGE', 'MATHS');
+		expect(useStaffingSelectionStore.getState().selection).toBeNull();
+		expect(useRightPanelStore.getState().isOpen).toBe(false);
+	});
+
+	it('toggling same support employee deselects and closes panel', () => {
+		useStaffingSelectionStore.getState().selectSupportEmployee(99, 'Administration');
+		expect(useStaffingSelectionStore.getState().selection).not.toBeNull();
+		expect(useRightPanelStore.getState().isOpen).toBe(true);
+
+		// Select the same employee again -> deselect
+		useStaffingSelectionStore.getState().selectSupportEmployee(99, 'Administration');
+		expect(useStaffingSelectionStore.getState().selection).toBeNull();
+		expect(useRightPanelStore.getState().isOpen).toBe(false);
+	});
+
+	it('switches from requirement line to support employee', () => {
+		useStaffingSelectionStore.getState().selectRequirementLine(42, 'COLLEGE', 'MATHS');
+		expect(useStaffingSelectionStore.getState().selection?.type).toBe('REQUIREMENT_LINE');
+
+		useStaffingSelectionStore.getState().selectSupportEmployee(99, 'Administration');
+		const selection = useStaffingSelectionStore.getState().selection;
+		expect(selection?.type).toBe('SUPPORT_EMPLOYEE');
+		if (selection?.type === 'SUPPORT_EMPLOYEE') {
+			expect(selection.employeeId).toBe(99);
+		}
+		expect(useRightPanelStore.getState().isOpen).toBe(true);
+	});
+
+	it('switches between different requirement lines', () => {
+		useStaffingSelectionStore.getState().selectRequirementLine(42, 'COLLEGE', 'MATHS');
+		expect(useStaffingSelectionStore.getState().selection).toEqual({
+			type: 'REQUIREMENT_LINE',
+			requirementLineId: 42,
+			band: 'COLLEGE',
+			disciplineCode: 'MATHS',
+		});
+
+		useStaffingSelectionStore.getState().selectRequirementLine(55, 'LYCEE', 'FRANCAIS');
+		expect(useStaffingSelectionStore.getState().selection).toEqual({
+			type: 'REQUIREMENT_LINE',
+			requirementLineId: 55,
+			band: 'LYCEE',
+			disciplineCode: 'FRANCAIS',
+		});
+		expect(useRightPanelStore.getState().isOpen).toBe(true);
+	});
+
+	it('clearSelection sets selection to null without closing panel', () => {
+		useStaffingSelectionStore.getState().selectRequirementLine(42, 'COLLEGE', 'MATHS');
+		expect(useRightPanelStore.getState().isOpen).toBe(true);
+
+		useStaffingSelectionStore.getState().clearSelection();
+		expect(useStaffingSelectionStore.getState().selection).toBeNull();
+		// clearSelection does not close the panel (that is handled by the page effect)
+		expect(useRightPanelStore.getState().isOpen).toBe(true);
+	});
+});

--- a/apps/web/src/stores/staffing-selection-store.ts
+++ b/apps/web/src/stores/staffing-selection-store.ts
@@ -1,0 +1,54 @@
+import { create } from 'zustand';
+import { useRightPanelStore } from './right-panel-store';
+
+export interface StaffingSelectionRequirementLine {
+	type: 'REQUIREMENT_LINE';
+	requirementLineId: number;
+	band: string;
+	disciplineCode: string;
+}
+
+export interface StaffingSelectionSupportEmployee {
+	type: 'SUPPORT_EMPLOYEE';
+	employeeId: number;
+	department: string;
+}
+
+export type StaffingSelection = StaffingSelectionRequirementLine | StaffingSelectionSupportEmployee;
+
+interface StaffingSelectionState {
+	selection: StaffingSelection | null;
+	selectRequirementLine: (requirementLineId: number, band: string, disciplineCode: string) => void;
+	selectSupportEmployee: (employeeId: number, department: string) => void;
+	clearSelection: () => void;
+}
+
+export const useStaffingSelectionStore = create<StaffingSelectionState>((set, get) => ({
+	selection: null,
+
+	selectRequirementLine: (requirementLineId, band, disciplineCode) => {
+		const current = get().selection;
+		if (current?.type === 'REQUIREMENT_LINE' && current.requirementLineId === requirementLineId) {
+			set({ selection: null });
+			useRightPanelStore.getState().close();
+			return;
+		}
+		set({
+			selection: { type: 'REQUIREMENT_LINE', requirementLineId, band, disciplineCode },
+		});
+		useRightPanelStore.getState().open('details');
+	},
+
+	selectSupportEmployee: (employeeId, department) => {
+		const current = get().selection;
+		if (current?.type === 'SUPPORT_EMPLOYEE' && current.employeeId === employeeId) {
+			set({ selection: null });
+			useRightPanelStore.getState().close();
+			return;
+		}
+		set({ selection: { type: 'SUPPORT_EMPLOYEE', employeeId, department } });
+		useRightPanelStore.getState().open('details');
+	},
+
+	clearSelection: () => set({ selection: null }),
+}));

--- a/apps/web/src/stores/staffing-settings-store.test.ts
+++ b/apps/web/src/stores/staffing-settings-store.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useStaffingSettingsSheetStore } from './staffing-settings-store';
+
+describe('useStaffingSettingsSheetStore', () => {
+	beforeEach(() => {
+		useStaffingSettingsSheetStore.getState().close();
+	});
+
+	afterEach(() => {
+		useStaffingSettingsSheetStore.getState().close();
+	});
+
+	it('starts with isOpen = false', () => {
+		expect(useStaffingSettingsSheetStore.getState().isOpen).toBe(false);
+	});
+
+	it('open() sets isOpen to true', () => {
+		useStaffingSettingsSheetStore.getState().open();
+		expect(useStaffingSettingsSheetStore.getState().isOpen).toBe(true);
+	});
+
+	it('close() sets isOpen to false', () => {
+		useStaffingSettingsSheetStore.getState().open();
+		expect(useStaffingSettingsSheetStore.getState().isOpen).toBe(true);
+
+		useStaffingSettingsSheetStore.getState().close();
+		expect(useStaffingSettingsSheetStore.getState().isOpen).toBe(false);
+	});
+
+	it('setOpen(true) sets isOpen to true', () => {
+		useStaffingSettingsSheetStore.getState().setOpen(true);
+		expect(useStaffingSettingsSheetStore.getState().isOpen).toBe(true);
+	});
+
+	it('setOpen(false) sets isOpen to false', () => {
+		useStaffingSettingsSheetStore.getState().setOpen(true);
+		useStaffingSettingsSheetStore.getState().setOpen(false);
+		expect(useStaffingSettingsSheetStore.getState().isOpen).toBe(false);
+	});
+});

--- a/apps/web/src/stores/staffing-settings-store.ts
+++ b/apps/web/src/stores/staffing-settings-store.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface StaffingSettingsSheetState {
+	isOpen: boolean;
+	open: () => void;
+	close: () => void;
+	setOpen: (open: boolean) => void;
+}
+
+export const useStaffingSettingsSheetStore = create<StaffingSettingsSheetState>((set) => ({
+	isOpen: false,
+	open: () => set({ isOpen: true }),
+	close: () => set({ isOpen: false }),
+	setOpen: (isOpen) => set({ isOpen }),
+}));


### PR DESCRIPTION
## Summary

- Rewrites `staffing.tsx` to match the enrollment page layout pattern (fixed-viewport, PlanningShell)
- Adds workspace mode toggle (Teaching / Support & Admin) with conditional toolbar controls
- Creates `staffing-selection-store.ts` Zustand store for requirement line / support employee selection
- Creates `staffing-settings-store.ts` Zustand store for settings sheet open/close state
- Extends `use-staffing.ts` with 14 new TanStack Query hooks (settings, overrides, requirements, assignments CRUD)
- Creates `use-master-data.ts` with 5 hooks (service profiles, disciplines, DHG rules, auto-suggest, demand overrides)
- Extracts types and `deriveStaffingEditability` to `staffing-workspace.ts`

Fixes #222
Part of Epic #221

## Test plan

- [x] 61 new tests across 5 test files (stores, hooks, page)
- [x] All 321 web tests pass (zero regressions)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Pre-push hooks (full test suite + typecheck) pass

Generated with [Claude Code](https://claude.com/claude-code)