### PR TITLE
Story 20-3: SupportAdminGrid and EmployeeForm Updates

### DIFF
--- a/apps/web/src/components/staffing/employee-form.test.tsx
+++ b/apps/web/src/components/staffing/employee-form.test.tsx
@@ -1,0 +1,407 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { EmployeeForm } from './employee-form';
+import type { Employee } from '../../hooks/use-staffing';
+
+afterEach(() => {
+	cleanup();
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeEmployee(overrides: Partial<Employee> & { id: number; name: string }): Employee {
+	return {
+		employeeCode: `EMP-${overrides.id}`,
+		department: 'Administration',
+		functionRole: 'Secretary',
+		status: 'Existing',
+		joiningDate: '2024-09-01',
+		paymentMethod: 'Bank',
+		isSaudi: false,
+		isAjeer: false,
+		isTeaching: false,
+		hourlyPercentage: '1.0000',
+		baseSalary: '5000',
+		housingAllowance: '1000',
+		transportAllowance: '500',
+		responsibilityPremium: null,
+		hsaAmount: null,
+		augmentation: null,
+		augmentationEffectiveDate: null,
+		ajeerAnnualLevy: '0',
+		ajeerMonthlyFee: '0',
+		updatedAt: '2026-03-01T00:00:00Z',
+		recordType: 'EMPLOYEE',
+		costMode: 'LOCAL_PAYROLL',
+		disciplineId: null,
+		serviceProfileId: null,
+		homeBand: null,
+		contractEndDate: null,
+		monthlyCost: '6500',
+		annualCost: '78000',
+		...overrides,
+	} as Employee;
+}
+
+const MOCK_DISCIPLINES = [
+	{ id: 1, code: 'FR', label: 'Francais', band: null },
+	{ id: 2, code: 'MATH', label: 'Mathematiques', band: null },
+];
+
+const MOCK_SERVICE_PROFILES = [
+	{ id: 1, code: 'CERT', label: 'Certifie', defaultOrs: '18', isHsaEligible: true },
+	{ id: 2, code: 'AGR', label: 'Agrege', defaultOrs: '15', isHsaEligible: true },
+];
+
+const defaultProps = {
+	open: true,
+	onClose: vi.fn(),
+	employee: null,
+	isReadOnly: false,
+	onSave: vi.fn(),
+	isPending: false,
+	disciplines: MOCK_DISCIPLINES,
+	serviceProfiles: MOCK_SERVICE_PROFILES,
+};
+
+// ── AC-10: Employee form 6 new fields ───────────────────────────────────────
+
+describe('EmployeeForm — new fields', () => {
+	describe('recordType field', () => {
+		it('renders recordType radio with Employee and Vacancy options', () => {
+			render(<EmployeeForm {...defaultProps} />);
+
+			expect(screen.getByLabelText('Employee')).toBeDefined();
+			expect(screen.getByLabelText('Vacancy')).toBeDefined();
+		});
+
+		it('defaults to Employee for new employees', () => {
+			render(<EmployeeForm {...defaultProps} />);
+
+			const employeeRadio = screen.getByLabelText('Employee') as HTMLInputElement;
+			expect(employeeRadio.checked).toBe(true);
+		});
+	});
+
+	describe('costMode field', () => {
+		it('renders costMode select with 3 options', () => {
+			render(<EmployeeForm {...defaultProps} />);
+
+			expect(screen.getAllByText(/Local Payroll/).length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('shows Local Payroll, AEFE Recharge, and No Local Cost options', async () => {
+			render(<EmployeeForm {...defaultProps} />);
+
+			// Find and click the costMode select trigger
+			const costModeLabel = screen.getByText(/Cost Mode/i);
+			expect(costModeLabel).toBeDefined();
+		});
+	});
+
+	describe('disciplineId field', () => {
+		it('shows discipline select when isTeaching is true', () => {
+			const teachingEmployee = makeEmployee({
+				id: 1,
+				name: 'Teacher A',
+				isTeaching: true,
+			});
+			render(<EmployeeForm {...defaultProps} employee={teachingEmployee} />);
+
+			expect(screen.getByText(/Discipline/)).toBeDefined();
+		});
+
+		it('hides discipline select when isTeaching is false', () => {
+			const nonTeachingEmployee = makeEmployee({
+				id: 1,
+				name: 'Admin A',
+				isTeaching: false,
+			});
+			render(<EmployeeForm {...defaultProps} employee={nonTeachingEmployee} />);
+
+			expect(screen.queryByText(/Discipline/)).toBeNull();
+		});
+	});
+
+	describe('serviceProfileId field', () => {
+		it('shows service profile select when isTeaching is true', () => {
+			const teachingEmployee = makeEmployee({
+				id: 1,
+				name: 'Teacher A',
+				isTeaching: true,
+			});
+			render(<EmployeeForm {...defaultProps} employee={teachingEmployee} />);
+
+			expect(screen.getByText(/Service Profile/)).toBeDefined();
+		});
+
+		it('hides service profile select when isTeaching is false', () => {
+			const nonTeachingEmployee = makeEmployee({
+				id: 1,
+				name: 'Admin A',
+				isTeaching: false,
+			});
+			render(<EmployeeForm {...defaultProps} employee={nonTeachingEmployee} />);
+
+			expect(screen.queryByText(/Service Profile/)).toBeNull();
+		});
+	});
+
+	describe('homeBand field', () => {
+		it('shows homeBand select with Mat/Elem/Col/Lyc when isTeaching', () => {
+			const teachingEmployee = makeEmployee({
+				id: 1,
+				name: 'Teacher A',
+				isTeaching: true,
+			});
+			render(<EmployeeForm {...defaultProps} employee={teachingEmployee} />);
+
+			expect(screen.getByText(/Home Band/)).toBeDefined();
+		});
+
+		it('hides homeBand when isTeaching is false', () => {
+			const nonTeachingEmployee = makeEmployee({
+				id: 1,
+				name: 'Admin A',
+				isTeaching: false,
+			});
+			render(<EmployeeForm {...defaultProps} employee={nonTeachingEmployee} />);
+
+			expect(screen.queryByText(/Home Band/)).toBeNull();
+		});
+	});
+
+	describe('contractEndDate field', () => {
+		it('always renders contractEndDate date picker', () => {
+			render(<EmployeeForm {...defaultProps} />);
+
+			expect(screen.getByText(/Contract End/)).toBeDefined();
+		});
+	});
+});
+
+describe('EmployeeForm — conditional visibility', () => {
+	describe('costMode = AEFE_RECHARGE', () => {
+		it('hides salary fields and shows info banner', () => {
+			const employee = makeEmployee({
+				id: 1,
+				name: 'Recharge Employee',
+				costMode: 'AEFE_RECHARGE',
+			});
+			render(<EmployeeForm {...defaultProps} employee={employee} />);
+
+			// Salary fields (Compensation section) should be hidden
+			expect(screen.queryByText(/Base Salary/)).toBeNull();
+			expect(screen.queryByText(/Housing Allowance/)).toBeNull();
+
+			// Info banner should be visible
+			expect(screen.getByText(/salary managed by AEFE recharge/i)).toBeDefined();
+		});
+	});
+
+	describe('costMode = NO_LOCAL_COST', () => {
+		it('hides salary and Ajeer fields', () => {
+			const employee = makeEmployee({
+				id: 1,
+				name: 'No Cost Employee',
+				costMode: 'NO_LOCAL_COST',
+			});
+			render(<EmployeeForm {...defaultProps} employee={employee} />);
+
+			// Salary fields should be hidden
+			expect(screen.queryByText(/Base Salary/)).toBeNull();
+
+			// Ajeer fields should be hidden
+			expect(screen.queryByText(/Annual Levy/)).toBeNull();
+			expect(screen.queryByText(/Monthly Fee/)).toBeNull();
+		});
+	});
+
+	describe('recordType = VACANCY', () => {
+		it('auto-generates VAC-NNN code and makes code read-only', () => {
+			render(<EmployeeForm {...defaultProps} employee={null} />);
+
+			// Switch to Vacancy mode
+			const vacancyRadio = screen.getByLabelText('Vacancy');
+			fireEvent.click(vacancyRadio);
+
+			// Employee code should contain VAC- prefix
+			const codeInput = screen.getByDisplayValue(/VAC-/);
+			expect(codeInput).toBeDefined();
+		});
+
+		it('hides Saudi and Ajeer flags for vacancy', () => {
+			const vacancy = makeEmployee({
+				id: 1,
+				name: '',
+				recordType: 'VACANCY',
+				employeeCode: 'VAC-001',
+			});
+			render(<EmployeeForm {...defaultProps} employee={vacancy} />);
+
+			expect(screen.queryByLabelText(/Saudi/)).toBeNull();
+			expect(screen.queryByLabelText(/Ajeer/)).toBeNull();
+		});
+
+		it('hides salary fields for vacancy', () => {
+			const vacancy = makeEmployee({
+				id: 1,
+				name: '',
+				recordType: 'VACANCY',
+				employeeCode: 'VAC-001',
+			});
+			render(<EmployeeForm {...defaultProps} employee={vacancy} />);
+
+			expect(screen.queryByText(/Base Salary/)).toBeNull();
+			expect(screen.queryByText(/Housing Allowance/)).toBeNull();
+		});
+	});
+
+	describe('isTeaching = false', () => {
+		it('hides teaching profile section', () => {
+			const nonTeaching = makeEmployee({
+				id: 1,
+				name: 'Admin A',
+				isTeaching: false,
+			});
+			render(<EmployeeForm {...defaultProps} employee={nonTeaching} />);
+
+			expect(screen.queryByText(/Teaching Profile/)).toBeNull();
+			expect(screen.queryByText(/Discipline/)).toBeNull();
+			expect(screen.queryByText(/Service Profile/)).toBeNull();
+			expect(screen.queryByText(/Home Band/)).toBeNull();
+		});
+	});
+
+	describe('isTeaching = true', () => {
+		it('shows teaching profile section with discipline, profile, and band', () => {
+			const teaching = makeEmployee({
+				id: 1,
+				name: 'Teacher A',
+				isTeaching: true,
+			});
+			render(<EmployeeForm {...defaultProps} employee={teaching} />);
+
+			expect(screen.getByText(/Teaching Profile/)).toBeDefined();
+			expect(screen.getByText(/Discipline/)).toBeDefined();
+			expect(screen.getByText(/Service Profile/)).toBeDefined();
+			expect(screen.getByText(/Home Band/)).toBeDefined();
+		});
+	});
+
+	describe('hsaAmount always hidden', () => {
+		it('does NOT render hsaAmount field in the form', () => {
+			const employee = makeEmployee({
+				id: 1,
+				name: 'Test Employee',
+				costMode: 'LOCAL_PAYROLL',
+			});
+			render(<EmployeeForm {...defaultProps} employee={employee} />);
+
+			expect(screen.queryByText(/HSA Amount/)).toBeNull();
+		});
+	});
+
+	describe('Ajeer section visibility', () => {
+		it('shows Ajeer section when isAjeer=true AND costMode=LOCAL_PAYROLL', () => {
+			const ajeerEmployee = makeEmployee({
+				id: 1,
+				name: 'Ajeer Worker',
+				isAjeer: true,
+				costMode: 'LOCAL_PAYROLL',
+			});
+			render(<EmployeeForm {...defaultProps} employee={ajeerEmployee} />);
+
+			expect(screen.getByText(/Annual Levy/)).toBeDefined();
+			expect(screen.getByText(/Monthly Fee/)).toBeDefined();
+		});
+
+		it('hides Ajeer section when isAjeer=false', () => {
+			const nonAjeer = makeEmployee({
+				id: 1,
+				name: 'Regular Employee',
+				isAjeer: false,
+				costMode: 'LOCAL_PAYROLL',
+			});
+			render(<EmployeeForm {...defaultProps} employee={nonAjeer} />);
+
+			// Ajeer section title should not be visible
+			// (the "Ajeer" checkbox label is visible but the section itself is hidden)
+			expect(screen.queryByText(/Annual Levy/)).toBeNull();
+		});
+
+		it('hides Ajeer section when costMode is not LOCAL_PAYROLL', () => {
+			const ajeerRecharge = makeEmployee({
+				id: 1,
+				name: 'AEFE Ajeer',
+				isAjeer: true,
+				costMode: 'AEFE_RECHARGE',
+			});
+			render(<EmployeeForm {...defaultProps} employee={ajeerRecharge} />);
+
+			expect(screen.queryByText(/Annual Levy/)).toBeNull();
+		});
+	});
+});
+
+describe('EmployeeForm — form sections', () => {
+	describe('Section 1: Identity', () => {
+		it('renders employee code, name, department, function role', () => {
+			render(<EmployeeForm {...defaultProps} />);
+
+			expect(screen.getByText(/Employee Code/)).toBeDefined();
+			expect(screen.getByText(/Full Name/)).toBeDefined();
+			expect(screen.getByText(/Department/)).toBeDefined();
+			expect(screen.getByText(/Function.*Role/i)).toBeDefined();
+		});
+	});
+
+	describe('Section 2: Classification', () => {
+		it('renders record type, status, cost mode, isTeaching', () => {
+			render(<EmployeeForm {...defaultProps} />);
+
+			expect(screen.getByText(/Record Type/i)).toBeDefined();
+			expect(screen.getByText(/Status/)).toBeDefined();
+			expect(screen.getByText(/Cost Mode/i)).toBeDefined();
+			expect(screen.getByLabelText(/Teaching/)).toBeDefined();
+		});
+	});
+
+	describe('Section 4: Employment', () => {
+		it('renders joining date, contract end date, payment method, hourly percentage', () => {
+			render(<EmployeeForm {...defaultProps} />);
+
+			expect(screen.getByText(/Joining Date/)).toBeDefined();
+			expect(screen.getByText(/Contract End/)).toBeDefined();
+			expect(screen.getByText(/Payment Method/)).toBeDefined();
+			expect(screen.getByText(/Hourly/)).toBeDefined();
+		});
+	});
+
+	describe('Section 5: Compensation (LOCAL_PAYROLL only)', () => {
+		it('shows compensation when costMode=LOCAL_PAYROLL', () => {
+			const employee = makeEmployee({
+				id: 1,
+				name: 'Test',
+				costMode: 'LOCAL_PAYROLL',
+			});
+			render(<EmployeeForm {...defaultProps} employee={employee} />);
+
+			expect(screen.getByText(/Base Salary/)).toBeDefined();
+			expect(screen.getByText(/Housing Allowance/)).toBeDefined();
+			expect(screen.getByText(/Transport Allowance/)).toBeDefined();
+		});
+
+		it('shows augmentation with effective date', () => {
+			const employee = makeEmployee({
+				id: 1,
+				name: 'Test',
+				costMode: 'LOCAL_PAYROLL',
+			});
+			render(<EmployeeForm {...defaultProps} employee={employee} />);
+
+			expect(screen.getByText(/Augmentation Effective Date/)).toBeDefined();
+			expect(screen.getAllByText(/Augmentation/).length).toBeGreaterThanOrEqual(2);
+		});
+	});
+});

--- a/apps/web/src/components/staffing/employee-form.tsx
+++ b/apps/web/src/components/staffing/employee-form.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '../ui/sheet';
 import { Button } from '../ui/button';
@@ -6,6 +6,8 @@ import { Input } from '../ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { cn } from '../../lib/cn';
 import type { Employee } from '../../hooks/use-staffing';
+
+// ── Form Data ───────────────────────────────────────────────────────────────
 
 export interface EmployeeFormData {
 	employeeCode: string;
@@ -25,9 +27,18 @@ export interface EmployeeFormData {
 	responsibilityPremium: string;
 	hsaAmount: string;
 	augmentation: string;
+	augmentationEffectiveDate: string;
 	ajeerAnnualLevy: string;
 	ajeerMonthlyFee: string;
+	recordType: string;
+	costMode: string;
+	disciplineId: string;
+	serviceProfileId: string;
+	homeBand: string;
+	contractEndDate: string;
 }
+
+// ── Props ───────────────────────────────────────────────────────────────────
 
 export type EmployeeFormProps = {
 	open: boolean;
@@ -37,10 +48,33 @@ export type EmployeeFormProps = {
 	onSave: (data: EmployeeFormData) => void;
 	onDelete?: () => void;
 	isPending: boolean;
+	disciplines?: Array<{ id: number; code: string; label: string; band: string | null }>;
+	serviceProfiles?: Array<{
+		id: number;
+		code: string;
+		label: string;
+		defaultOrs: string;
+		isHsaEligible: boolean;
+	}>;
 };
+
+// ── Constants ───────────────────────────────────────────────────────────────
 
 const DEPARTMENTS = ['Teaching', 'Administration', 'Support', 'Management', 'Maintenance'];
 const STATUSES = ['Existing', 'New', 'Departed'];
+const COST_MODES = [
+	{ value: 'LOCAL_PAYROLL', label: 'Local Payroll' },
+	{ value: 'AEFE_RECHARGE', label: 'AEFE Recharge' },
+	{ value: 'NO_LOCAL_COST', label: 'No Local Cost' },
+];
+const HOME_BANDS = [
+	{ value: 'MATERNELLE', label: 'Mat' },
+	{ value: 'ELEMENTAIRE', label: 'Elem' },
+	{ value: 'COLLEGE', label: 'Col' },
+	{ value: 'LYCEE', label: 'Lyc' },
+];
+
+// ── Field helper ────────────────────────────────────────────────────────────
 
 function Field({
 	label,
@@ -60,6 +94,28 @@ function Field({
 	);
 }
 
+// ── Section Header ──────────────────────────────────────────────────────────
+
+function SectionHeader({ title }: { title: string }) {
+	return (
+		<h3 className="text-(--text-sm) font-semibold text-(--text-primary) border-b border-(--workspace-border) pb-1">
+			{title}
+		</h3>
+	);
+}
+
+// ── Vacancy code generator ──────────────────────────────────────────────────
+
+let vacancyCounter = 1;
+
+function generateVacancyCode(): string {
+	const code = `VAC-${String(vacancyCounter).padStart(3, '0')}`;
+	vacancyCounter++;
+	return code;
+}
+
+// ── Main Component ──────────────────────────────────────────────────────────
+
 export function EmployeeForm({
 	open,
 	onClose,
@@ -68,6 +124,8 @@ export function EmployeeForm({
 	onSave,
 	onDelete,
 	isPending,
+	disciplines = [],
+	serviceProfiles = [],
 }: EmployeeFormProps) {
 	const isNew = !employee;
 
@@ -76,6 +134,8 @@ export function EmployeeForm({
 		handleSubmit,
 		reset,
 		control,
+		watch,
+		setValue,
 		formState: { errors },
 	} = useForm<EmployeeFormData>({
 		defaultValues: {
@@ -96,10 +156,38 @@ export function EmployeeForm({
 			responsibilityPremium: '0',
 			hsaAmount: '0',
 			augmentation: '0',
+			augmentationEffectiveDate: '',
 			ajeerAnnualLevy: '0',
 			ajeerMonthlyFee: '0',
+			recordType: 'EMPLOYEE',
+			costMode: 'LOCAL_PAYROLL',
+			disciplineId: '',
+			serviceProfileId: '',
+			homeBand: '',
+			contractEndDate: '',
 		},
 	});
+
+	// Watch fields for conditional visibility
+	const watchRecordType = watch('recordType');
+	const watchCostMode = watch('costMode');
+	const watchIsTeaching = watch('isTeaching');
+	const watchIsAjeer = watch('isAjeer');
+
+	// Derived visibility flags
+	const isVacancy = watchRecordType === 'VACANCY';
+	const isLocalPayroll = watchCostMode === 'LOCAL_PAYROLL';
+	const isAefeRecharge = watchCostMode === 'AEFE_RECHARGE';
+	const _isNoCost = watchCostMode === 'NO_LOCAL_COST';
+
+	const showTeachingProfile = watchIsTeaching === true;
+	const showCompensation = isLocalPayroll && !isVacancy;
+	const showAjeerSection = watchIsAjeer === true && isLocalPayroll && !isVacancy;
+	const showSaudiAjeerFlags = !isVacancy;
+	const showSalaryInfoBanner = isAefeRecharge && !isVacancy;
+
+	// Auto-generate vacancy code when switching to VACANCY
+	const vacancyCode = useMemo(() => generateVacancyCode(), []);
 
 	useEffect(() => {
 		if (employee) {
@@ -121,13 +209,27 @@ export function EmployeeForm({
 				responsibilityPremium: employee.responsibilityPremium ?? '0',
 				hsaAmount: employee.hsaAmount ?? '0',
 				augmentation: employee.augmentation ?? '0',
+				augmentationEffectiveDate: employee.augmentationEffectiveDate?.split('T')[0] ?? '',
 				ajeerAnnualLevy: employee.ajeerAnnualLevy ?? '0',
 				ajeerMonthlyFee: employee.ajeerMonthlyFee ?? '0',
+				recordType: employee.recordType ?? 'EMPLOYEE',
+				costMode: employee.costMode ?? 'LOCAL_PAYROLL',
+				disciplineId: employee.disciplineId ? String(employee.disciplineId) : '',
+				serviceProfileId: employee.serviceProfileId ? String(employee.serviceProfileId) : '',
+				homeBand: employee.homeBand ?? '',
+				contractEndDate: employee.contractEndDate?.split('T')[0] ?? '',
 			});
 		} else {
 			reset();
 		}
 	}, [employee, reset]);
+
+	// When recordType changes to VACANCY, set vacancy code
+	useEffect(() => {
+		if (watchRecordType === 'VACANCY' && isNew) {
+			setValue('employeeCode', vacancyCode);
+		}
+	}, [watchRecordType, isNew, setValue, vacancyCode]);
 
 	const inputClass = cn(
 		'w-full rounded-md',
@@ -147,12 +249,12 @@ export function EmployeeForm({
 				</SheetHeader>
 
 				<form onSubmit={handleSubmit(onSave)} className="mt-6 space-y-4" aria-label="Employee form">
-					{/* Identity */}
+					{/* Section 1: Identity */}
 					<div className="grid grid-cols-2 gap-3">
 						<Field label="Employee Code" error={errors.employeeCode?.message}>
 							<Input
 								{...register('employeeCode', { required: 'Required' })}
-								disabled={isReadOnly || !isNew}
+								disabled={isReadOnly || !isNew || isVacancy}
 								className={inputClass}
 							/>
 						</Field>
@@ -180,7 +282,9 @@ export function EmployeeForm({
 
 					<Field label="Full Name" error={errors.name?.message}>
 						<Input
-							{...register('name', { required: 'Required' })}
+							{...register('name', {
+								required: isVacancy ? false : 'Required',
+							})}
 							disabled={isReadOnly}
 							className={inputClass}
 						/>
@@ -216,40 +320,57 @@ export function EmployeeForm({
 						</Field>
 					</div>
 
-					<div className="grid grid-cols-2 gap-3">
-						<Field label="Joining Date" error={errors.joiningDate?.message}>
-							<Input
-								type="date"
-								{...register('joiningDate', { required: 'Required' })}
-								disabled={isReadOnly}
-								className={inputClass}
-							/>
-						</Field>
-						<Field label="Payment Method">
-							<Input {...register('paymentMethod')} disabled={isReadOnly} className={inputClass} />
-						</Field>
-					</div>
+					{/* Section 2: Classification */}
+					<SectionHeader title="Classification" />
 
-					{/* Flags */}
+					<Field label="Record Type">
+						<div className="flex gap-4 py-1">
+							<label className="flex items-center gap-2 text-sm">
+								<input
+									type="radio"
+									value="EMPLOYEE"
+									{...register('recordType')}
+									disabled={isReadOnly}
+									className="rounded"
+								/>
+								Employee
+							</label>
+							<label className="flex items-center gap-2 text-sm">
+								<input
+									type="radio"
+									value="VACANCY"
+									{...register('recordType')}
+									disabled={isReadOnly}
+									className="rounded"
+								/>
+								Vacancy
+							</label>
+						</div>
+					</Field>
+
+					<Field label="Cost Mode">
+						<Controller
+							control={control}
+							name="costMode"
+							render={({ field }) => (
+								<Select value={field.value} onValueChange={field.onChange} disabled={isReadOnly}>
+									<SelectTrigger className={selectClass}>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{COST_MODES.map((cm) => (
+											<SelectItem key={cm.value} value={cm.value}>
+												{cm.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							)}
+						/>
+					</Field>
+
+					{/* Flags: Teaching always visible; Saudi/Ajeer hidden for VACANCY */}
 					<div className="flex gap-6 py-2">
-						<label className="flex items-center gap-2 text-sm">
-							<input
-								type="checkbox"
-								{...register('isSaudi')}
-								disabled={isReadOnly}
-								className="rounded"
-							/>
-							Saudi
-						</label>
-						<label className="flex items-center gap-2 text-sm">
-							<input
-								type="checkbox"
-								{...register('isAjeer')}
-								disabled={isReadOnly}
-								className="rounded"
-							/>
-							Ajeer
-						</label>
 						<label className="flex items-center gap-2 text-sm">
 							<input
 								type="checkbox"
@@ -259,14 +380,163 @@ export function EmployeeForm({
 							/>
 							Teaching
 						</label>
+						{showSaudiAjeerFlags && (
+							<>
+								<label className="flex items-center gap-2 text-sm">
+									<input
+										type="checkbox"
+										{...register('isSaudi')}
+										disabled={isReadOnly}
+										className="rounded"
+									/>
+									Saudi
+								</label>
+								<label className="flex items-center gap-2 text-sm">
+									<input
+										type="checkbox"
+										{...register('isAjeer')}
+										disabled={isReadOnly}
+										className="rounded"
+									/>
+									Ajeer
+								</label>
+							</>
+						)}
 					</div>
 
-					{/* Salary Fields */}
-					{!isReadOnly && (
+					{/* Section 3: Teaching Profile (visible when isTeaching=true) */}
+					{showTeachingProfile && (
 						<>
-							<h3 className="text-(--text-sm) font-semibold text-(--text-primary) border-b border-(--workspace-border) pb-1">
-								Compensation
-							</h3>
+							<SectionHeader title="Teaching Profile" />
+
+							<Field label="Discipline">
+								<Controller
+									control={control}
+									name="disciplineId"
+									render={({ field }) => (
+										<Select
+											value={field.value}
+											onValueChange={field.onChange}
+											disabled={isReadOnly}
+										>
+											<SelectTrigger className={selectClass}>
+												<SelectValue placeholder="Select discipline" />
+											</SelectTrigger>
+											<SelectContent>
+												{disciplines.map((d) => (
+													<SelectItem key={d.id} value={String(d.id)}>
+														{d.label}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									)}
+								/>
+							</Field>
+
+							<Field label="Service Profile">
+								<Controller
+									control={control}
+									name="serviceProfileId"
+									render={({ field }) => (
+										<Select
+											value={field.value}
+											onValueChange={field.onChange}
+											disabled={isReadOnly}
+										>
+											<SelectTrigger className={selectClass}>
+												<SelectValue placeholder="Select service profile" />
+											</SelectTrigger>
+											<SelectContent>
+												{serviceProfiles.map((sp) => (
+													<SelectItem key={sp.id} value={String(sp.id)}>
+														{sp.label} ({sp.code})
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									)}
+								/>
+							</Field>
+
+							<Field label="Home Band">
+								<Controller
+									control={control}
+									name="homeBand"
+									render={({ field }) => (
+										<Select
+											value={field.value}
+											onValueChange={field.onChange}
+											disabled={isReadOnly}
+										>
+											<SelectTrigger className={selectClass}>
+												<SelectValue placeholder="Select home band" />
+											</SelectTrigger>
+											<SelectContent>
+												{HOME_BANDS.map((b) => (
+													<SelectItem key={b.value} value={b.value}>
+														{b.label}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									)}
+								/>
+							</Field>
+						</>
+					)}
+
+					{/* Section 4: Employment */}
+					<SectionHeader title="Employment" />
+					<div className="grid grid-cols-2 gap-3">
+						<Field label="Joining Date" error={errors.joiningDate?.message}>
+							<Input
+								type="date"
+								{...register('joiningDate', { required: 'Required' })}
+								disabled={isReadOnly}
+								className={inputClass}
+							/>
+						</Field>
+						<Field label="Contract End Date">
+							<Input
+								type="date"
+								{...register('contractEndDate')}
+								disabled={isReadOnly}
+								className={inputClass}
+							/>
+						</Field>
+					</div>
+					<div className="grid grid-cols-2 gap-3">
+						<Field label="Payment Method">
+							<Input {...register('paymentMethod')} disabled={isReadOnly} className={inputClass} />
+						</Field>
+						<Field label="Hourly %">
+							<Input
+								type="number"
+								step="0.0001"
+								{...register('hourlyPercentage')}
+								disabled={isReadOnly}
+								className={inputClass}
+							/>
+						</Field>
+					</div>
+
+					{/* AEFE Recharge info banner */}
+					{showSalaryInfoBanner && (
+						<div
+							className={cn(
+								'rounded-md border border-(--color-info-bg) bg-(--color-info-bg)/10',
+								'px-3 py-2 text-sm text-(--color-info)'
+							)}
+						>
+							Salary managed by AEFE recharge. Configure recharge amounts in Staffing Settings.
+						</div>
+					)}
+
+					{/* Section 5: Compensation (LOCAL_PAYROLL only, not VACANCY) */}
+					{showCompensation && !isReadOnly && (
+						<>
+							<SectionHeader title="Compensation" />
 							<div className="grid grid-cols-2 gap-3">
 								<Field label="Base Salary (SAR)" error={errors.baseSalary?.message}>
 									<Input
@@ -280,7 +550,9 @@ export function EmployeeForm({
 									<Input
 										type="number"
 										step="0.01"
-										{...register('housingAllowance', { required: 'Required' })}
+										{...register('housingAllowance', {
+											required: 'Required',
+										})}
 										className={inputClass}
 									/>
 								</Field>
@@ -288,7 +560,9 @@ export function EmployeeForm({
 									<Input
 										type="number"
 										step="0.01"
-										{...register('transportAllowance', { required: 'Required' })}
+										{...register('transportAllowance', {
+											required: 'Required',
+										})}
 										className={inputClass}
 									/>
 								</Field>
@@ -300,14 +574,7 @@ export function EmployeeForm({
 										className={inputClass}
 									/>
 								</Field>
-								<Field label="HSA Amount">
-									<Input
-										type="number"
-										step="0.01"
-										{...register('hsaAmount')}
-										className={inputClass}
-									/>
-								</Field>
+								{/* hsaAmount is ALWAYS hidden (computed by pipeline) */}
 								<Field label="Augmentation">
 									<Input
 										type="number"
@@ -316,19 +583,21 @@ export function EmployeeForm({
 										className={inputClass}
 									/>
 								</Field>
-								<Field label="Hourly %">
+								<Field label="Augmentation Effective Date">
 									<Input
-										type="number"
-										step="0.0001"
-										{...register('hourlyPercentage')}
+										type="date"
+										{...register('augmentationEffectiveDate')}
 										className={inputClass}
 									/>
 								</Field>
 							</div>
+						</>
+					)}
 
-							<h3 className="text-(--text-sm) font-semibold text-(--text-primary) border-b border-(--workspace-border) pb-1">
-								Ajeer
-							</h3>
+					{/* Section 6: Ajeer Details (isAjeer AND LOCAL_PAYROLL, not VACANCY) */}
+					{showAjeerSection && !isReadOnly && (
+						<>
+							<SectionHeader title="Ajeer Details" />
 							<div className="grid grid-cols-2 gap-3">
 								<Field label="Annual Levy">
 									<Input

--- a/apps/web/src/components/staffing/employee-grid.test.tsx
+++ b/apps/web/src/components/staffing/employee-grid.test.tsx
@@ -29,6 +29,14 @@ function makeEmployee(overrides: Partial<Employee> & { id: number; name: string 
 		ajeerAnnualLevy: '0',
 		ajeerMonthlyFee: '0',
 		updatedAt: '2026-03-01T00:00:00Z',
+		recordType: 'EMPLOYEE',
+		costMode: 'LOCAL_PAYROLL',
+		disciplineId: null,
+		serviceProfileId: null,
+		homeBand: null,
+		contractEndDate: null,
+		monthlyCost: null,
+		annualCost: null,
 		...overrides,
 	};
 }

--- a/apps/web/src/components/staffing/staff-costs-department-grid.test.tsx
+++ b/apps/web/src/components/staffing/staff-costs-department-grid.test.tsx
@@ -33,6 +33,14 @@ function makeEmployee(overrides: Partial<Employee> = {}): Employee {
 		ajeerAnnualLevy: '9660.00',
 		ajeerMonthlyFee: '805.00',
 		updatedAt: '2026-01-01T00:00:00Z',
+		recordType: 'EMPLOYEE',
+		costMode: 'LOCAL_PAYROLL',
+		disciplineId: null,
+		serviceProfileId: null,
+		homeBand: null,
+		contractEndDate: null,
+		monthlyCost: null,
+		annualCost: null,
 		...overrides,
 	};
 }

--- a/apps/web/src/components/staffing/support-admin-grid.test.tsx
+++ b/apps/web/src/components/staffing/support-admin-grid.test.tsx
@@ -1,0 +1,541 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { SupportAdminGrid } from './support-admin-grid';
+import type { Employee } from '../../hooks/use-staffing';
+
+afterEach(() => {
+	cleanup();
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeEmployee(overrides: Partial<Employee> & { id: number; name: string }): Employee {
+	return {
+		employeeCode: `EMP-${overrides.id}`,
+		department: 'Administration',
+		functionRole: 'Secretary',
+		status: 'Existing',
+		joiningDate: '2024-09-01',
+		paymentMethod: 'Bank',
+		isSaudi: false,
+		isAjeer: false,
+		isTeaching: false,
+		hourlyPercentage: '1.0000',
+		baseSalary: '5000',
+		housingAllowance: '1000',
+		transportAllowance: '500',
+		responsibilityPremium: null,
+		hsaAmount: null,
+		augmentation: null,
+		augmentationEffectiveDate: null,
+		ajeerAnnualLevy: '0',
+		ajeerMonthlyFee: '0',
+		updatedAt: '2026-03-01T00:00:00Z',
+		recordType: 'EMPLOYEE',
+		costMode: 'LOCAL_PAYROLL',
+		disciplineId: null,
+		serviceProfileId: null,
+		homeBand: null,
+		contractEndDate: null,
+		monthlyCost: '6500',
+		annualCost: '78000',
+		...overrides,
+	} as Employee;
+}
+
+const EMPLOYEES: Employee[] = [
+	makeEmployee({
+		id: 1,
+		name: 'Alice Martin',
+		department: 'Administration',
+		functionRole: 'Admin Assistant',
+		status: 'Existing',
+		hourlyPercentage: '1.0000',
+		monthlyCost: '8000',
+		annualCost: '96000',
+	}),
+	makeEmployee({
+		id: 2,
+		name: 'Bob Dupont',
+		department: 'Administration',
+		functionRole: 'Office Manager',
+		status: 'New',
+		hourlyPercentage: '1.0000',
+		monthlyCost: '10000',
+		annualCost: '120000',
+	}),
+	makeEmployee({
+		id: 3,
+		name: 'Charlie Bernard',
+		department: 'Maintenance',
+		functionRole: 'Janitor',
+		status: 'Existing',
+		hourlyPercentage: '0.5000',
+		monthlyCost: '3000',
+		annualCost: '36000',
+	}),
+	makeEmployee({
+		id: 4,
+		name: '',
+		department: 'IT',
+		functionRole: 'IT Support',
+		status: 'Vacancy',
+		employeeCode: 'VAC-001',
+		recordType: 'VACANCY',
+		hourlyPercentage: '1.0000',
+		monthlyCost: '7000',
+		annualCost: '84000',
+	}),
+];
+
+// ── AC-09: SupportAdminGrid renders ─────────────────────────────────────────
+
+describe('SupportAdminGrid', () => {
+	describe('department grouping', () => {
+		it('renders department group headers', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			expect(screen.getByText('Administration')).toBeDefined();
+			expect(screen.getByText('Maintenance')).toBeDefined();
+			expect(screen.getByText('IT')).toBeDefined();
+		});
+
+		it('shows employee count in department headers', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			// Administration has 2 employees
+			const adminHeader = screen.getByText('Administration').closest('tr')!;
+			expect(adminHeader.textContent).toContain('2');
+		});
+
+		it('shows subtotal annual cost in department headers', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			// Administration subtotal = 96000 + 120000 = 216000
+			const adminHeader = screen.getByText('Administration').closest('tr')!;
+			// SAR compact format -- exact text depends on formatMoney
+			expect(adminHeader.textContent).toMatch(/216/);
+		});
+
+		it('department headers are collapsible', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			const deptRows = screen
+				.getAllByRole('row')
+				.filter((row) => row.getAttribute('aria-expanded') !== null);
+			expect(deptRows.length).toBeGreaterThanOrEqual(3);
+		});
+	});
+
+	describe('column rendering', () => {
+		it('renders all 8 column headers', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			// Check for the 8 required columns
+			expect(screen.getByText('Name / Position')).toBeDefined();
+			expect(screen.getByText('Role')).toBeDefined();
+			expect(screen.getByText('Status')).toBeDefined();
+			expect(screen.getByText('FTE')).toBeDefined();
+			expect(screen.getByText('Start')).toBeDefined();
+			expect(screen.getByText('End')).toBeDefined();
+			expect(screen.getByText('Monthly')).toBeDefined();
+			expect(screen.getByText('Annual')).toBeDefined();
+		});
+	});
+
+	describe('status badges', () => {
+		it('renders Existing status badge with info styling', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			// Expand Administration to see Alice (Existing)
+			const adminRow = screen
+				.getAllByRole('row')
+				.find((r) => r.textContent?.includes('Administration'))!;
+			fireEvent.click(adminRow);
+
+			const existingBadges = screen.getAllByText('Existing');
+			expect(existingBadges.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('renders New status badge with success styling', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			// Expand Administration to see Bob (New)
+			const adminRow = screen
+				.getAllByRole('row')
+				.find((r) => r.textContent?.includes('Administration'))!;
+			fireEvent.click(adminRow);
+
+			expect(screen.getByText('New')).toBeDefined();
+		});
+
+		it('renders Vacancy status badge with muted styling', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			// Expand IT to see vacancy
+			const itRow = screen.getAllByRole('row').find((r) => r.textContent?.includes('IT'))!;
+			fireEvent.click(itRow);
+
+			expect(screen.getByText('Vacancy')).toBeDefined();
+		});
+	});
+
+	describe('vacancy display', () => {
+		it('shows "Vacancy: [role]" in muted italic for vacancy rows', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			// Expand IT
+			const itRow = screen.getAllByRole('row').find((r) => r.textContent?.includes('IT'))!;
+			fireEvent.click(itRow);
+
+			const vacancyText = screen.getByText(/Vacancy: IT Support/);
+			expect(vacancyText).toBeDefined();
+			expect(vacancyText.className).toContain('italic');
+		});
+	});
+
+	describe('row interaction', () => {
+		it('clicking a row calls onEmployeeSelect with the employee', () => {
+			const onSelect = vi.fn();
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={onSelect}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			// Expand Administration
+			const adminRow = screen
+				.getAllByRole('row')
+				.find((r) => r.textContent?.includes('Administration'))!;
+			fireEvent.click(adminRow);
+
+			// Click Alice's row
+			const aliceRow = screen.getByText('Alice Martin').closest('tr')!;
+			fireEvent.click(aliceRow);
+
+			expect(onSelect).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 1, name: 'Alice Martin' })
+			);
+		});
+
+		it('double-clicking a row calls onEmployeeDoubleClick when editable', () => {
+			const onDoubleClick = vi.fn();
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={onDoubleClick}
+				/>
+			);
+
+			// Expand Administration
+			const adminRow = screen
+				.getAllByRole('row')
+				.find((r) => r.textContent?.includes('Administration'))!;
+			fireEvent.click(adminRow);
+
+			// Double-click Alice's row
+			const aliceRow = screen.getByText('Alice Martin').closest('tr')!;
+			fireEvent.doubleClick(aliceRow);
+
+			expect(onDoubleClick).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 1, name: 'Alice Martin' })
+			);
+		});
+
+		it('double-clicking does NOT call onEmployeeDoubleClick when locked', () => {
+			const onDoubleClick = vi.fn();
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="locked"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={onDoubleClick}
+				/>
+			);
+
+			// Expand Administration
+			const adminRow = screen
+				.getAllByRole('row')
+				.find((r) => r.textContent?.includes('Administration'))!;
+			fireEvent.click(adminRow);
+
+			// Double-click Alice's row
+			const aliceRow = screen.getByText('Alice Martin').closest('tr')!;
+			fireEvent.doubleClick(aliceRow);
+
+			expect(onDoubleClick).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('grand total row', () => {
+		it('renders a grand total row at the bottom', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			expect(screen.getByText('TOTAL')).toBeDefined();
+		});
+
+		it('grand total shows sum of all annual costs', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			// Grand total = 96000 + 120000 + 36000 + 84000 = 336000
+			const totalRow = screen.getByText('TOTAL').closest('tr')!;
+			expect(totalRow.textContent).toMatch(/336/);
+		});
+	});
+
+	describe('empty state', () => {
+		it('shows empty message when no non-teaching employees', () => {
+			render(
+				<SupportAdminGrid
+					employees={[]}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			expect(screen.getByText(/no.*employees/i)).toBeDefined();
+		});
+	});
+
+	describe('accessibility', () => {
+		it('table has role="table" (read-only grid)', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			const table = screen.getByRole('table');
+			expect(table).toBeDefined();
+			expect(table.getAttribute('aria-label')).toBe('Support and admin employees');
+		});
+
+		it('has aria-live region for announcements', () => {
+			const { container } = render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			const liveRegion = container.querySelector('[aria-live="polite"]');
+			expect(liveRegion).toBeDefined();
+		});
+
+		it('keyboard Enter/Space toggles department expand/collapse', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			const adminRow = screen
+				.getAllByRole('row')
+				.find((r) => r.textContent?.includes('Administration'))!;
+
+			expect(adminRow.getAttribute('aria-expanded')).toBe('false');
+
+			fireEvent.keyDown(adminRow, { key: 'Enter' });
+			expect(adminRow.getAttribute('aria-expanded')).toBe('true');
+
+			fireEvent.keyDown(adminRow, { key: ' ' });
+			expect(adminRow.getAttribute('aria-expanded')).toBe('false');
+		});
+	});
+
+	describe('monetary formatting', () => {
+		it('formats monthly cost using SAR compact format via font-mono', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			// Expand Administration
+			const adminRow = screen
+				.getAllByRole('row')
+				.find((r) => r.textContent?.includes('Administration'))!;
+			fireEvent.click(adminRow);
+
+			// Find a cell with monthly cost -- "8000" or formatted SAR equivalent
+			const aliceRow = screen.getByText('Alice Martin').closest('tr')!;
+			expect(aliceRow.textContent).toMatch(/8/); // Should show monetary value
+		});
+
+		it('annual cost cells use bold font weight', () => {
+			render(
+				<SupportAdminGrid
+					employees={EMPLOYEES}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			// Expand Administration
+			const adminRow = screen
+				.getAllByRole('row')
+				.find((r) => r.textContent?.includes('Administration'))!;
+			fireEvent.click(adminRow);
+
+			// Find annual cost cells -- they should use font-semibold or font-bold
+			const aliceRow = screen.getByText('Alice Martin').closest('tr')!;
+			const cells = aliceRow.querySelectorAll('td');
+			const lastCell = cells[cells.length - 1]!; // annual cost is last column
+			expect(lastCell.className).toMatch(/font-(bold|semibold)/);
+		});
+	});
+
+	describe('date formatting', () => {
+		it('shows contract end date when present', () => {
+			const employees = [
+				makeEmployee({
+					id: 1,
+					name: 'Alice',
+					contractEndDate: '2027-06-30',
+				}),
+			];
+
+			render(
+				<SupportAdminGrid
+					employees={employees}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			// Expand department
+			const deptRow = screen
+				.getAllByRole('row')
+				.find((r) => r.getAttribute('aria-expanded') !== null)!;
+			fireEvent.click(deptRow);
+
+			// Should show a date representation of 2027-06-30
+			const aliceRow = screen.getByText('Alice').closest('tr')!;
+			expect(aliceRow.textContent).toMatch(/Jun|2027/);
+		});
+
+		it('shows dash when contractEndDate is null', () => {
+			const employees = [
+				makeEmployee({
+					id: 1,
+					name: 'Alice',
+					contractEndDate: null,
+				}),
+			];
+
+			render(
+				<SupportAdminGrid
+					employees={employees}
+					editability="editable"
+					onEmployeeSelect={() => {}}
+					onEmployeeDoubleClick={() => {}}
+				/>
+			);
+
+			// Expand department
+			const deptRow = screen
+				.getAllByRole('row')
+				.find((r) => r.getAttribute('aria-expanded') !== null)!;
+			fireEvent.click(deptRow);
+
+			const aliceRow = screen.getByText('Alice').closest('tr')!;
+			expect(aliceRow.textContent).toContain('\u2014'); // em dash
+		});
+	});
+});

--- a/apps/web/src/components/staffing/support-admin-grid.tsx
+++ b/apps/web/src/components/staffing/support-admin-grid.tsx
@@ -1,0 +1,511 @@
+import { useMemo, useState, useCallback, useRef } from 'react';
+import { cn } from '../../lib/cn';
+import { formatMoney } from '../../lib/format-money';
+import { buildSupportGridRows } from '../../lib/staffing-workspace';
+import type { Employee } from '../../hooks/use-staffing';
+import type { StaffingEditability, SupportDepartmentGroup } from '../../lib/staffing-workspace';
+import { format, parseISO } from 'date-fns';
+
+// ── Props ───────────────────────────────────────────────────────────────────
+
+export type SupportAdminGridProps = {
+	employees: Employee[];
+	editability: StaffingEditability;
+	onEmployeeSelect: (employee: Employee) => void;
+	onEmployeeDoubleClick: (employee: Employee) => void;
+};
+
+// ── Status Badge ────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: string }) {
+	const color =
+		status === 'Existing'
+			? 'bg-(--color-info-bg) text-(--color-info)'
+			: status === 'New'
+				? 'bg-(--color-success-bg) text-(--color-success)'
+				: 'bg-(--workspace-bg-muted) text-(--text-muted)';
+	return (
+		<span className={cn('inline-flex rounded-full px-2 py-0.5 text-xs font-medium', color)}>
+			{status}
+		</span>
+	);
+}
+
+// ── Date formatter ──────────────────────────────────────────────────────────
+
+function formatDate(dateStr: string | null): string {
+	if (!dateStr) return '\u2014';
+	try {
+		return format(parseISO(dateStr), 'dd MMM yyyy');
+	} catch {
+		return '\u2014';
+	}
+}
+
+// ── Name cell renderer ──────────────────────────────────────────────────────
+
+function NameCell({ employee }: { employee: Employee }) {
+	if (employee.recordType === 'VACANCY') {
+		return <span className="italic text-(--text-muted)">Vacancy: {employee.functionRole}</span>;
+	}
+	return <span>{employee.name}</span>;
+}
+
+// ── Main Grid ───────────────────────────────────────────────────────────────
+
+export function SupportAdminGrid({
+	employees,
+	editability,
+	onEmployeeSelect,
+	onEmployeeDoubleClick,
+}: SupportAdminGridProps) {
+	const [expandedDepartments, setExpandedDepartments] = useState<Set<string>>(new Set());
+	const liveRegionRef = useRef<HTMLDivElement>(null);
+
+	const groups = useMemo(() => buildSupportGridRows(employees), [employees]);
+
+	const grandTotalAnnual = useMemo(() => {
+		let total = 0;
+		for (const g of groups) {
+			total += parseFloat(g.subtotalAnnualCost);
+		}
+		return total;
+	}, [groups]);
+
+	const announce = useCallback((message: string) => {
+		if (liveRegionRef.current) {
+			liveRegionRef.current.textContent = message;
+		}
+	}, []);
+
+	const toggleDepartment = useCallback(
+		(department: string, group: SupportDepartmentGroup) => {
+			setExpandedDepartments((prev) => {
+				const next = new Set(prev);
+				if (next.has(department)) {
+					next.delete(department);
+					announce(`${department} collapsed`);
+				} else {
+					next.add(department);
+					announce(`${department} expanded, ${group.employeeCount} employees`);
+				}
+				return next;
+			});
+		},
+		[announce]
+	);
+
+	const handleDepartmentKeyDown = useCallback(
+		(e: React.KeyboardEvent, group: SupportDepartmentGroup) => {
+			const isExpanded = expandedDepartments.has(group.department);
+
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				toggleDepartment(group.department, group);
+			} else if (e.key === 'ArrowRight' && !isExpanded) {
+				e.preventDefault();
+				setExpandedDepartments((prev) => {
+					const next = new Set(prev);
+					next.add(group.department);
+					announce(`${group.department} expanded, ${group.employeeCount} employees`);
+					return next;
+				});
+			} else if (e.key === 'ArrowLeft' && isExpanded) {
+				e.preventDefault();
+				setExpandedDepartments((prev) => {
+					const next = new Set(prev);
+					next.delete(group.department);
+					announce(`${group.department} collapsed`);
+					return next;
+				});
+			}
+		},
+		[expandedDepartments, toggleDepartment, announce]
+	);
+
+	const handleRowClick = useCallback(
+		(employee: Employee) => {
+			onEmployeeSelect(employee);
+		},
+		[onEmployeeSelect]
+	);
+
+	const handleRowDoubleClick = useCallback(
+		(employee: Employee) => {
+			if (editability === 'editable') {
+				onEmployeeDoubleClick(employee);
+			}
+		},
+		[editability, onEmployeeDoubleClick]
+	);
+
+	const totalEmployees = groups.reduce((sum, g) => sum + g.employeeCount, 0);
+
+	return (
+		<div className="space-y-0">
+			{/* Screen reader live region */}
+			<div ref={liveRegionRef} aria-live="polite" aria-atomic="true" className="sr-only" />
+
+			<div className={cn('overflow-x-auto rounded-md', 'border border-(--workspace-border)')}>
+				<table
+					className="w-full border-collapse text-sm"
+					role="table"
+					aria-label="Support and admin employees"
+					aria-rowcount={totalEmployees + groups.length + 2}
+					aria-colcount={8}
+				>
+					<thead>
+						<tr className="bg-(--workspace-bg-subtle)">
+							<th
+								className={cn(
+									'w-9 px-2 py-2 text-left font-medium',
+									'text-(--text-muted)',
+									'text-xs uppercase tracking-wider',
+									'border-b border-(--workspace-border)'
+								)}
+								aria-label="Expand or collapse"
+							/>
+							<th
+								className={cn(
+									'px-3 py-2 text-left font-medium text-(--text-muted)',
+									'text-xs uppercase tracking-wider',
+									'border-b border-(--workspace-border)'
+								)}
+								style={{ width: 200 }}
+							>
+								Name / Position
+							</th>
+							<th
+								className={cn(
+									'px-3 py-2 text-left font-medium text-(--text-muted)',
+									'text-xs uppercase tracking-wider',
+									'border-b border-(--workspace-border)'
+								)}
+								style={{ width: 150 }}
+							>
+								Role
+							</th>
+							<th
+								className={cn(
+									'px-3 py-2 text-center font-medium text-(--text-muted)',
+									'text-xs uppercase tracking-wider',
+									'border-b border-(--workspace-border)'
+								)}
+								style={{ width: 90 }}
+							>
+								Status
+							</th>
+							<th
+								className={cn(
+									'px-3 py-2 text-right font-medium text-(--text-muted)',
+									'text-xs uppercase tracking-wider',
+									'border-b border-(--workspace-border)'
+								)}
+								style={{ width: 60 }}
+							>
+								FTE
+							</th>
+							<th
+								className={cn(
+									'px-3 py-2 text-center font-medium text-(--text-muted)',
+									'text-xs uppercase tracking-wider',
+									'border-b border-(--workspace-border)'
+								)}
+								style={{ width: 90 }}
+							>
+								Start
+							</th>
+							<th
+								className={cn(
+									'px-3 py-2 text-center font-medium text-(--text-muted)',
+									'text-xs uppercase tracking-wider',
+									'border-b border-(--workspace-border)'
+								)}
+								style={{ width: 90 }}
+							>
+								End
+							</th>
+							<th
+								className={cn(
+									'px-3 py-2 text-right font-medium text-(--text-muted)',
+									'text-xs uppercase tracking-wider',
+									'border-b border-(--workspace-border)'
+								)}
+								style={{ width: 100 }}
+							>
+								Monthly
+							</th>
+							<th
+								className={cn(
+									'px-3 py-2 text-right font-medium text-(--text-muted)',
+									'text-xs uppercase tracking-wider',
+									'border-b border-(--workspace-border)'
+								)}
+								style={{ width: 110 }}
+							>
+								Annual
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{groups.length === 0 ? (
+							<tr>
+								<td colSpan={9} className="px-3 py-8 text-center text-(--text-muted)">
+									No support or admin employees found.
+								</td>
+							</tr>
+						) : (
+							<>
+								{groups.map((group) => {
+									const isExpanded = expandedDepartments.has(group.department);
+									return (
+										<DepartmentSection
+											key={group.department}
+											group={group}
+											isExpanded={isExpanded}
+											editability={editability}
+											onToggle={() => toggleDepartment(group.department, group)}
+											onKeyDown={(e) => handleDepartmentKeyDown(e, group)}
+											onRowClick={handleRowClick}
+											onRowDoubleClick={handleRowDoubleClick}
+										/>
+									);
+								})}
+								{/* Grand Total Row */}
+								<tr
+									className={cn(
+										'bg-(--workspace-bg-subtle)',
+										'font-semibold border-t-2 border-(--workspace-border)'
+									)}
+								>
+									<td className="w-9 px-2 py-2 border-b border-(--workspace-border)" />
+									<td
+										colSpan={7}
+										className="px-3 py-2 text-(--text-primary) border-b border-(--workspace-border)"
+									>
+										TOTAL
+									</td>
+									<td
+										className={cn(
+											'px-3 py-2 text-right font-bold',
+											'font-mono tabular-nums',
+											'text-(--text-primary)',
+											'border-b border-(--workspace-border)'
+										)}
+									>
+										{formatMoney(grandTotalAnnual, {
+											showCurrency: true,
+											compact: true,
+										})}
+									</td>
+								</tr>
+							</>
+						)}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	);
+}
+
+// ── Department Section (avoid re-renders across groups) ─────────────────────
+
+type DepartmentSectionProps = {
+	group: SupportDepartmentGroup;
+	isExpanded: boolean;
+	editability: StaffingEditability;
+	onToggle: () => void;
+	onKeyDown: (e: React.KeyboardEvent) => void;
+	onRowClick: (employee: Employee) => void;
+	onRowDoubleClick: (employee: Employee) => void;
+};
+
+function DepartmentSection({
+	group,
+	isExpanded,
+	editability,
+	onToggle,
+	onKeyDown,
+	onRowClick,
+	onRowDoubleClick,
+}: DepartmentSectionProps) {
+	return (
+		<>
+			{/* Department group header */}
+			<tr
+				className={cn(
+					'cursor-pointer select-none bg-(--workspace-bg-muted)',
+					'hover:bg-(--workspace-bg-subtle)',
+					'transition-colors'
+				)}
+				role="row"
+				aria-expanded={isExpanded}
+				tabIndex={0}
+				onClick={onToggle}
+				onKeyDown={onKeyDown}
+				data-department={group.department}
+			>
+				<td className="w-9 px-2 py-2 border-b border-(--workspace-border)">
+					<span
+						className={cn(
+							'inline-flex h-5 w-5 items-center justify-center',
+							'text-(--text-muted) transition-transform',
+							isExpanded && 'rotate-90'
+						)}
+						aria-hidden="true"
+					>
+						&#9654;
+					</span>
+				</td>
+				<td
+					colSpan={6}
+					className={cn(
+						'px-3 py-2 font-semibold text-(--text-primary)',
+						'border-b border-(--workspace-border)'
+					)}
+				>
+					{group.department}
+					<span
+						className={cn(
+							'ml-2 inline-flex items-center rounded-full',
+							'bg-(--accent-50) px-2 py-0.5',
+							'text-xs font-medium text-(--accent-700)'
+						)}
+					>
+						{group.employeeCount}
+					</span>
+				</td>
+				<td
+					colSpan={2}
+					className={cn(
+						'px-3 py-2 text-right font-mono tabular-nums',
+						'text-(--text-primary) font-semibold',
+						'border-b border-(--workspace-border)'
+					)}
+				>
+					{formatMoney(group.subtotalAnnualCost, {
+						showCurrency: true,
+						compact: true,
+					})}
+				</td>
+			</tr>
+
+			{/* Employee detail rows */}
+			{isExpanded &&
+				group.employees.map((emp) => (
+					<EmployeeRow
+						key={emp.id}
+						employee={emp}
+						editability={editability}
+						onClick={() => onRowClick(emp)}
+						onDoubleClick={() => onRowDoubleClick(emp)}
+					/>
+				))}
+		</>
+	);
+}
+
+// ── Employee Row ────────────────────────────────────────────────────────────
+
+type EmployeeRowProps = {
+	employee: Employee;
+	editability: StaffingEditability;
+	onClick: () => void;
+	onDoubleClick: () => void;
+};
+
+function EmployeeRow({ employee, onClick, onDoubleClick }: EmployeeRowProps) {
+	return (
+		<tr
+			className={cn('cursor-pointer transition-colors', 'hover:bg-(--workspace-bg-subtle)')}
+			role="row"
+			aria-level={2}
+			tabIndex={0}
+			onClick={onClick}
+			onDoubleClick={onDoubleClick}
+			onKeyDown={(e) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					onClick();
+				}
+			}}
+		>
+			<td className="w-9 border-b border-(--workspace-border)" />
+			<td
+				className={cn(
+					'px-3 py-2 pl-6 text-(--text-primary)',
+					'border-b border-(--workspace-border)'
+				)}
+				style={{ width: 200 }}
+			>
+				<NameCell employee={employee} />
+			</td>
+			<td
+				className={cn('px-3 py-2 text-(--text-primary)', 'border-b border-(--workspace-border)')}
+				style={{ width: 150 }}
+			>
+				{employee.functionRole}
+			</td>
+			<td
+				className={cn('px-3 py-2 text-center', 'border-b border-(--workspace-border)')}
+				style={{ width: 90 }}
+			>
+				<StatusBadge status={employee.status} />
+			</td>
+			<td
+				className={cn(
+					'px-3 py-2 text-right font-mono tabular-nums',
+					'text-(--text-primary)',
+					'border-b border-(--workspace-border)'
+				)}
+				style={{ width: 60 }}
+			>
+				{parseFloat(employee.hourlyPercentage).toFixed(2)}
+			</td>
+			<td
+				className={cn(
+					'px-3 py-2 text-center',
+					'text-(--text-primary)',
+					'border-b border-(--workspace-border)'
+				)}
+				style={{ width: 90 }}
+			>
+				{formatDate(employee.joiningDate)}
+			</td>
+			<td
+				className={cn(
+					'px-3 py-2 text-center',
+					'text-(--text-primary)',
+					'border-b border-(--workspace-border)'
+				)}
+				style={{ width: 90 }}
+			>
+				{formatDate(employee.contractEndDate)}
+			</td>
+			<td
+				className={cn(
+					'px-3 py-2 text-right font-mono tabular-nums',
+					'text-(--text-primary)',
+					'border-b border-(--workspace-border)'
+				)}
+				style={{ width: 100 }}
+			>
+				{employee.monthlyCost
+					? formatMoney(employee.monthlyCost, { showCurrency: true, compact: true })
+					: '\u2014'}
+			</td>
+			<td
+				className={cn(
+					'px-3 py-2 text-right font-mono tabular-nums font-semibold',
+					'text-(--text-primary)',
+					'border-b border-(--workspace-border)'
+				)}
+				style={{ width: 110 }}
+			>
+				{employee.annualCost
+					? formatMoney(employee.annualCost, { showCurrency: true, compact: true })
+					: '\u2014'}
+			</td>
+		</tr>
+	);
+}

--- a/apps/web/src/hooks/use-staffing.ts
+++ b/apps/web/src/hooks/use-staffing.ts
@@ -27,6 +27,14 @@ export interface Employee {
 	ajeerAnnualLevy: string;
 	ajeerMonthlyFee: string;
 	updatedAt: string;
+	recordType: string;
+	costMode: string;
+	disciplineId: number | null;
+	serviceProfileId: number | null;
+	homeBand: string | null;
+	contractEndDate: string | null;
+	monthlyCost: string | null;
+	annualCost: string | null;
 }
 
 export interface EmployeeListResponse {

--- a/apps/web/src/lib/staffing-workspace.test.ts
+++ b/apps/web/src/lib/staffing-workspace.test.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect } from 'vitest';
+import {
+	buildSupportGridRows,
+	buildTeachingGridRows,
+	filterTeachingRows,
+} from './staffing-workspace';
+import type { TeachingGridRow } from './staffing-workspace';
+import type { Employee, TeachingRequirementLine } from '../hooks/use-staffing';
+
+// ── Support Grid Helpers ───────────────────────────────────────────────────
+
+function makeEmployee(overrides: Partial<Employee> & { id: number; name: string }): Employee {
+	return {
+		employeeCode: `EMP-${overrides.id}`,
+		department: 'Administration',
+		functionRole: 'Secretary',
+		status: 'Existing',
+		joiningDate: '2024-09-01',
+		paymentMethod: 'Bank',
+		isSaudi: false,
+		isAjeer: false,
+		isTeaching: false,
+		hourlyPercentage: '1.0000',
+		baseSalary: '5000',
+		housingAllowance: '1000',
+		transportAllowance: '500',
+		responsibilityPremium: null,
+		hsaAmount: null,
+		augmentation: null,
+		augmentationEffectiveDate: null,
+		ajeerAnnualLevy: '0',
+		ajeerMonthlyFee: '0',
+		updatedAt: '2026-03-01T00:00:00Z',
+		recordType: 'EMPLOYEE',
+		costMode: 'LOCAL_PAYROLL',
+		disciplineId: null,
+		serviceProfileId: null,
+		homeBand: null,
+		contractEndDate: null,
+		monthlyCost: '6500',
+		annualCost: '78000',
+		...overrides,
+	} as Employee;
+}
+
+// ── Support Grid Tests ─────────────────────────────────────────────────────
+
+describe('buildSupportGridRows', () => {
+	it('groups non-teaching employees by department', () => {
+		const employees = [
+			makeEmployee({ id: 1, name: 'Alice', department: 'Administration' }),
+			makeEmployee({ id: 2, name: 'Bob', department: 'Administration' }),
+			makeEmployee({ id: 3, name: 'Charlie', department: 'Maintenance' }),
+		];
+
+		const groups = buildSupportGridRows(employees);
+		expect(groups.length).toBe(2);
+
+		const admin = groups.find((g) => g.department === 'Administration');
+		expect(admin).toBeDefined();
+		expect(admin!.employees.length).toBe(2);
+
+		const maintenance = groups.find((g) => g.department === 'Maintenance');
+		expect(maintenance).toBeDefined();
+		expect(maintenance!.employees.length).toBe(1);
+	});
+
+	it('filters out teaching employees', () => {
+		const employees = [
+			makeEmployee({ id: 1, name: 'Alice', isTeaching: false }),
+			makeEmployee({ id: 2, name: 'Bob', isTeaching: true }),
+		];
+
+		const groups = buildSupportGridRows(employees);
+		const allEmployees = groups.flatMap((g) => g.employees);
+		expect(allEmployees.length).toBe(1);
+		expect(allEmployees[0]!.name).toBe('Alice');
+	});
+
+	it('computes department subtotal annual cost', () => {
+		const employees = [
+			makeEmployee({ id: 1, name: 'Alice', department: 'Admin', annualCost: '50000' }),
+			makeEmployee({ id: 2, name: 'Bob', department: 'Admin', annualCost: '60000' }),
+		];
+
+		const groups = buildSupportGridRows(employees);
+		expect(groups[0]!.subtotalAnnualCost).toBe('110000');
+	});
+
+	it('computes employee count per department', () => {
+		const employees = [
+			makeEmployee({ id: 1, name: 'Alice', department: 'Support' }),
+			makeEmployee({ id: 2, name: 'Bob', department: 'Support' }),
+			makeEmployee({ id: 3, name: 'Charlie', department: 'Support' }),
+		];
+
+		const groups = buildSupportGridRows(employees);
+		expect(groups[0]!.employeeCount).toBe(3);
+	});
+
+	it('computes grand total across all departments', () => {
+		const employees = [
+			makeEmployee({ id: 1, name: 'Alice', department: 'Admin', annualCost: '50000' }),
+			makeEmployee({ id: 2, name: 'Bob', department: 'Support', annualCost: '40000' }),
+		];
+
+		const groups = buildSupportGridRows(employees);
+		const grandTotal = groups.reduce((sum, g) => sum + parseFloat(g.subtotalAnnualCost), 0);
+		expect(grandTotal).toBe(90000);
+	});
+
+	it('returns empty array for no non-teaching employees', () => {
+		const employees = [makeEmployee({ id: 1, name: 'Teacher A', isTeaching: true })];
+
+		const groups = buildSupportGridRows(employees);
+		expect(groups.length).toBe(0);
+	});
+
+	it('handles vacancies in employee list', () => {
+		const employees = [
+			makeEmployee({
+				id: 1,
+				name: '',
+				recordType: 'VACANCY',
+				employeeCode: 'VAC-001',
+				functionRole: 'IT Support',
+				department: 'IT',
+				status: 'Vacancy',
+			}),
+		];
+
+		const groups = buildSupportGridRows(employees);
+		expect(groups.length).toBe(1);
+		expect(groups[0]!.employees[0]!.employeeCode).toBe('VAC-001');
+	});
+});
+
+// ── Teaching Grid Pure Function Fixtures ────────────────────────────────────
+
+function makeLine(overrides: Partial<TeachingRequirementLine> = {}): TeachingRequirementLine {
+	return {
+		id: 1,
+		band: 'MATERNELLE',
+		disciplineCode: 'FR',
+		lineLabel: 'Francais - Maternelle',
+		lineType: 'Structural',
+		serviceProfileCode: 'PE',
+		totalDriverUnits: 10,
+		totalWeeklyHours: '15.0',
+		baseOrs: '24.0',
+		effectiveOrs: '24.0',
+		requiredFteRaw: '0.63',
+		requiredFtePlanned: '1.00',
+		recommendedPositions: 1,
+		coveredFte: '0.63',
+		gapFte: '0.00',
+		coverageStatus: 'COVERED',
+		assignedStaffCount: 1,
+		directCostAnnual: '120000.00',
+		hsaCostAnnual: '5000.00',
+		...overrides,
+	};
+}
+
+const SAMPLE_LINES: TeachingRequirementLine[] = [
+	makeLine({
+		id: 1,
+		band: 'MATERNELLE',
+		disciplineCode: 'FR',
+		lineLabel: 'Francais - Maternelle',
+		requiredFteRaw: '2.50',
+		coveredFte: '2.00',
+		gapFte: '-0.50',
+		coverageStatus: 'DEFICIT',
+	}),
+	makeLine({
+		id: 2,
+		band: 'MATERNELLE',
+		disciplineCode: 'MA',
+		lineLabel: 'Maths - Maternelle',
+		requiredFteRaw: '1.50',
+		coveredFte: '1.50',
+		gapFte: '0.00',
+		coverageStatus: 'COVERED',
+	}),
+	makeLine({
+		id: 3,
+		band: 'ELEMENTAIRE',
+		disciplineCode: 'FR',
+		lineLabel: 'Francais - Elementaire',
+		requiredFteRaw: '3.00',
+		coveredFte: '3.50',
+		gapFte: '0.50',
+		coverageStatus: 'SURPLUS',
+	}),
+	makeLine({
+		id: 4,
+		band: 'COLLEGE',
+		disciplineCode: 'SCI',
+		lineLabel: 'Sciences - College',
+		requiredFteRaw: '2.00',
+		coveredFte: '0.00',
+		gapFte: '-2.00',
+		coverageStatus: 'UNCOVERED',
+	}),
+	makeLine({
+		id: 5,
+		band: 'LYCEE',
+		disciplineCode: 'PHI',
+		lineLabel: 'Philosophie - Lycee',
+		requiredFteRaw: '1.00',
+		coveredFte: '1.00',
+		gapFte: '0.00',
+		coverageStatus: 'COVERED',
+	}),
+];
+
+// ── AC-05: buildTeachingGridRows — band grouping and ordering ──────────────
+
+describe('buildTeachingGridRows', () => {
+	it('groups rows by band in the correct display order: MAT -> ELEM -> COL -> LYC', () => {
+		const mixedLines = [
+			SAMPLE_LINES[4]!, // LYCEE
+			SAMPLE_LINES[0]!, // MATERNELLE
+			SAMPLE_LINES[3]!, // COLLEGE
+			SAMPLE_LINES[2]!, // ELEMENTAIRE
+			SAMPLE_LINES[1]!, // MATERNELLE
+		];
+		const result = buildTeachingGridRows(mixedLines);
+
+		const requirementRows = result.filter((r) => r.rowType === 'requirement');
+		const bands = requirementRows.map((r) => r.band);
+		const uniqueBands = [...new Set(bands)];
+
+		expect(uniqueBands).toEqual(['MATERNELLE', 'ELEMENTAIRE', 'COLLEGE', 'LYCEE']);
+	});
+
+	it('returns requirement rows with all fields from the API line', () => {
+		const result = buildTeachingGridRows([SAMPLE_LINES[0]!]);
+		const requirementRows = result.filter((r) => r.rowType === 'requirement');
+
+		expect(requirementRows).toHaveLength(1);
+		const row = requirementRows[0]!;
+		expect(row.rowType).toBe('requirement');
+		expect(row.id).toBe(1);
+		expect(row.band).toBe('MATERNELLE');
+		expect(row.lineLabel).toBe('Francais - Maternelle');
+		expect(row.requiredFteRaw).toBe('2.50');
+		expect(row.coverageStatus).toBe('DEFICIT');
+	});
+
+	it('includes subtotal rows per band with summed FTE values', () => {
+		const result = buildTeachingGridRows(SAMPLE_LINES);
+		const subtotalRows = result.filter((r) => r.rowType === 'subtotal');
+
+		expect(subtotalRows.length).toBe(4);
+
+		const matSubtotal = subtotalRows.find((r) => r.band === 'MATERNELLE');
+		expect(matSubtotal).toBeDefined();
+		expect(matSubtotal!.requiredFteRaw).toBe('4.00');
+		expect(matSubtotal!.coveredFte).toBe('3.50');
+		expect(matSubtotal!.gapFte).toBe('-0.50');
+	});
+
+	it('returns empty array for empty input', () => {
+		const result = buildTeachingGridRows([]);
+		expect(result).toEqual([]);
+	});
+
+	it('preserves all 15 column fields in requirement rows', () => {
+		const line = SAMPLE_LINES[0]!;
+		const result = buildTeachingGridRows([line]);
+		const row = result.find((r) => r.rowType === 'requirement')!;
+
+		expect(row.lineLabel).toBe(line.lineLabel);
+		expect(row.serviceProfileCode).toBe(line.serviceProfileCode);
+		expect(row.totalDriverUnits).toBe(line.totalDriverUnits);
+		expect(row.totalWeeklyHours).toBe(line.totalWeeklyHours);
+		expect(row.baseOrs).toBe(line.baseOrs);
+		expect(row.effectiveOrs).toBe(line.effectiveOrs);
+		expect(row.requiredFteRaw).toBe(line.requiredFteRaw);
+		expect(row.requiredFtePlanned).toBe(line.requiredFtePlanned);
+		expect(row.recommendedPositions).toBe(line.recommendedPositions);
+		expect(row.coveredFte).toBe(line.coveredFte);
+		expect(row.gapFte).toBe(line.gapFte);
+		expect(row.coverageStatus).toBe(line.coverageStatus);
+		expect(row.assignedStaffCount).toBe(line.assignedStaffCount);
+		expect(row.directCostAnnual).toBe(line.directCostAnnual);
+		expect(row.hsaCostAnnual).toBe(line.hsaCostAnnual);
+	});
+
+	it('computes band line count correctly for the subtotal', () => {
+		const result = buildTeachingGridRows(SAMPLE_LINES);
+		const matSubtotal = result.find((r) => r.rowType === 'subtotal' && r.band === 'MATERNELLE');
+		expect(matSubtotal!.lineCount).toBe(2);
+	});
+});
+
+// ── AC-07: filterTeachingRows — band and coverage filters ──────────────────
+
+describe('filterTeachingRows', () => {
+	const allRows: TeachingGridRow[] = SAMPLE_LINES.map((line) => ({
+		rowType: 'requirement' as const,
+		id: line.id,
+		band: line.band,
+		disciplineCode: line.disciplineCode,
+		lineLabel: line.lineLabel,
+		lineType: line.lineType,
+		serviceProfileCode: line.serviceProfileCode,
+		totalDriverUnits: line.totalDriverUnits,
+		totalWeeklyHours: line.totalWeeklyHours,
+		baseOrs: line.baseOrs,
+		effectiveOrs: line.effectiveOrs,
+		requiredFteRaw: line.requiredFteRaw,
+		requiredFtePlanned: line.requiredFtePlanned,
+		recommendedPositions: line.recommendedPositions,
+		coveredFte: line.coveredFte,
+		gapFte: line.gapFte,
+		coverageStatus: line.coverageStatus,
+		assignedStaffCount: line.assignedStaffCount,
+		directCostAnnual: line.directCostAnnual,
+		hsaCostAnnual: line.hsaCostAnnual,
+	}));
+
+	it('returns all rows when both filters are ALL', () => {
+		const result = filterTeachingRows(allRows, 'ALL', 'ALL');
+		expect(result).toHaveLength(5);
+	});
+
+	it('filters by band when band filter is set (MAT)', () => {
+		const result = filterTeachingRows(allRows, 'MAT', 'ALL');
+		expect(result).toHaveLength(2);
+		expect(result.every((r) => r.band === 'MATERNELLE')).toBe(true);
+	});
+
+	it('filters by ELEM band correctly', () => {
+		const result = filterTeachingRows(allRows, 'ELEM', 'ALL');
+		expect(result).toHaveLength(1);
+		expect(result[0]!.band).toBe('ELEMENTAIRE');
+	});
+
+	it('filters by COL band correctly', () => {
+		const result = filterTeachingRows(allRows, 'COL', 'ALL');
+		expect(result).toHaveLength(1);
+		expect(result[0]!.band).toBe('COLLEGE');
+	});
+
+	it('filters by LYC band correctly', () => {
+		const result = filterTeachingRows(allRows, 'LYC', 'ALL');
+		expect(result).toHaveLength(1);
+		expect(result[0]!.band).toBe('LYCEE');
+	});
+
+	it('filters by coverage status DEFICIT', () => {
+		const result = filterTeachingRows(allRows, 'ALL', 'DEFICIT');
+		expect(result).toHaveLength(1);
+		expect(result[0]!.coverageStatus).toBe('DEFICIT');
+	});
+
+	it('filters by coverage status COVERED', () => {
+		const result = filterTeachingRows(allRows, 'ALL', 'COVERED');
+		expect(result).toHaveLength(2);
+		expect(result.every((r) => r.coverageStatus === 'COVERED')).toBe(true);
+	});
+
+	it('filters by coverage status SURPLUS', () => {
+		const result = filterTeachingRows(allRows, 'ALL', 'SURPLUS');
+		expect(result).toHaveLength(1);
+		expect(result[0]!.coverageStatus).toBe('SURPLUS');
+	});
+
+	it('filters by coverage status UNCOVERED', () => {
+		const result = filterTeachingRows(allRows, 'ALL', 'UNCOVERED');
+		expect(result).toHaveLength(1);
+		expect(result[0]!.coverageStatus).toBe('UNCOVERED');
+	});
+
+	it('applies band and coverage filters additively', () => {
+		const result = filterTeachingRows(allRows, 'MAT', 'DEFICIT');
+		expect(result).toHaveLength(1);
+		expect(result[0]!.band).toBe('MATERNELLE');
+		expect(result[0]!.coverageStatus).toBe('DEFICIT');
+	});
+
+	it('returns empty array when no rows match combined filters', () => {
+		const result = filterTeachingRows(allRows, 'LYC', 'DEFICIT');
+		expect(result).toHaveLength(0);
+	});
+
+	it('returns empty array for empty input', () => {
+		const result = filterTeachingRows([], 'ALL', 'ALL');
+		expect(result).toHaveLength(0);
+	});
+});
+
+// ── AC-08: Totals compute from requiredFteRaw, never recommendedPositions ──
+
+describe('buildTeachingGridRows — subtotal computations (AC-08)', () => {
+	it('subtotals compute from requiredFteRaw (continuous decimal), not recommendedPositions', () => {
+		const lines: TeachingRequirementLine[] = [
+			makeLine({
+				id: 10,
+				band: 'MATERNELLE',
+				requiredFteRaw: '1.33',
+				recommendedPositions: 2,
+			}),
+			makeLine({
+				id: 11,
+				band: 'MATERNELLE',
+				requiredFteRaw: '0.67',
+				recommendedPositions: 1,
+			}),
+		];
+
+		const result = buildTeachingGridRows(lines);
+		const matSubtotal = result.find((r) => r.rowType === 'subtotal' && r.band === 'MATERNELLE');
+
+		expect(matSubtotal!.requiredFteRaw).toBe('2.00');
+	});
+
+	it('subtotals sum coveredFte and gapFte as well', () => {
+		const lines: TeachingRequirementLine[] = [
+			makeLine({
+				id: 20,
+				band: 'ELEMENTAIRE',
+				coveredFte: '1.25',
+				gapFte: '-0.75',
+			}),
+			makeLine({
+				id: 21,
+				band: 'ELEMENTAIRE',
+				coveredFte: '2.00',
+				gapFte: '0.25',
+			}),
+		];
+
+		const result = buildTeachingGridRows(lines);
+		const elemSubtotal = result.find((r) => r.rowType === 'subtotal' && r.band === 'ELEMENTAIRE');
+
+		expect(elemSubtotal!.coveredFte).toBe('3.25');
+		expect(elemSubtotal!.gapFte).toBe('-0.50');
+	});
+});

--- a/apps/web/src/lib/staffing-workspace.ts
+++ b/apps/web/src/lib/staffing-workspace.ts
@@ -41,3 +41,218 @@ export const COVERAGE_OPTIONS: Array<{ value: CoverageFilter; label: string }> =
 	{ value: 'UNCOVERED', label: 'Uncovered' },
 	{ value: 'COVERED', label: 'Covered' },
 ];
+
+// ── Teaching Grid Types ─────────────────────────────────────────────────────
+
+export interface TeachingGridRow {
+	rowType: 'requirement' | 'subtotal' | 'total';
+	id: number;
+	band: string;
+	disciplineCode: string;
+	lineLabel: string;
+	lineType: string;
+	serviceProfileCode: string;
+	totalDriverUnits: number;
+	totalWeeklyHours: string;
+	baseOrs: string;
+	effectiveOrs: string;
+	requiredFteRaw: string;
+	requiredFtePlanned: string;
+	recommendedPositions: number;
+	coveredFte: string;
+	gapFte: string;
+	coverageStatus: string;
+	assignedStaffCount: number;
+	directCostAnnual: string;
+	hsaCostAnnual: string;
+	lineCount?: number;
+}
+
+/** Canonical display order for bands. */
+const BAND_ORDER: Record<string, number> = {
+	MATERNELLE: 1,
+	ELEMENTAIRE: 2,
+	COLLEGE: 3,
+	LYCEE: 4,
+};
+
+/** Map from short filter key to full band name. */
+const BAND_FILTER_MAP: Record<string, string> = {
+	MAT: 'MATERNELLE',
+	ELEM: 'ELEMENTAIRE',
+	COL: 'COLLEGE',
+	LYC: 'LYCEE',
+};
+
+/**
+ * Build band-grouped rows from API teaching requirement lines.
+ * Sorts by band display order (MAT -> ELEM -> COL -> LYC),
+ * adds subtotal rows per band, computes from requiredFteRaw (never recommendedPositions).
+ */
+export function buildTeachingGridRows(
+	lines: import('../hooks/use-staffing').TeachingRequirementLine[]
+): TeachingGridRow[] {
+	if (lines.length === 0) return [];
+
+	// Sort lines by band display order, preserving original order within each band
+	const sorted = [...lines].sort((a, b) => {
+		const orderA = BAND_ORDER[a.band] ?? 99;
+		const orderB = BAND_ORDER[b.band] ?? 99;
+		return orderA - orderB;
+	});
+
+	// Group by band
+	const bandGroups = new Map<string, typeof sorted>();
+	for (const line of sorted) {
+		const existing = bandGroups.get(line.band);
+		if (existing) {
+			existing.push(line);
+		} else {
+			bandGroups.set(line.band, [line]);
+		}
+	}
+
+	const result: TeachingGridRow[] = [];
+
+	for (const [band, bandLines] of bandGroups) {
+		// Add requirement rows for this band
+		for (const line of bandLines) {
+			result.push({
+				rowType: 'requirement',
+				id: line.id,
+				band: line.band,
+				disciplineCode: line.disciplineCode,
+				lineLabel: line.lineLabel,
+				lineType: line.lineType,
+				serviceProfileCode: line.serviceProfileCode,
+				totalDriverUnits: line.totalDriverUnits,
+				totalWeeklyHours: line.totalWeeklyHours,
+				baseOrs: line.baseOrs,
+				effectiveOrs: line.effectiveOrs,
+				requiredFteRaw: line.requiredFteRaw,
+				requiredFtePlanned: line.requiredFtePlanned,
+				recommendedPositions: line.recommendedPositions,
+				coveredFte: line.coveredFte,
+				gapFte: line.gapFte,
+				coverageStatus: line.coverageStatus,
+				assignedStaffCount: line.assignedStaffCount,
+				directCostAnnual: line.directCostAnnual,
+				hsaCostAnnual: line.hsaCostAnnual,
+			});
+		}
+
+		// Compute band subtotals using requiredFteRaw (continuous decimal, not positions)
+		let sumFteRaw = 0;
+		let sumCovered = 0;
+		let sumGap = 0;
+		for (const line of bandLines) {
+			sumFteRaw += parseFloat(line.requiredFteRaw);
+			sumCovered += parseFloat(line.coveredFte);
+			sumGap += parseFloat(line.gapFte);
+		}
+
+		result.push({
+			rowType: 'subtotal',
+			id: 0,
+			band,
+			disciplineCode: '',
+			lineLabel: `${band} Subtotal`,
+			lineType: '',
+			serviceProfileCode: '',
+			totalDriverUnits: 0,
+			totalWeeklyHours: '0',
+			baseOrs: '0',
+			effectiveOrs: '0',
+			requiredFteRaw: sumFteRaw.toFixed(2),
+			requiredFtePlanned: '0',
+			recommendedPositions: 0,
+			coveredFte: sumCovered.toFixed(2),
+			gapFte: sumGap.toFixed(2),
+			coverageStatus: '',
+			assignedStaffCount: 0,
+			directCostAnnual: '0',
+			hsaCostAnnual: '0',
+			lineCount: bandLines.length,
+		});
+	}
+
+	return result;
+}
+
+/**
+ * Filter teaching grid rows by band and coverage status.
+ * Both filters are additive (applied simultaneously).
+ * Only filters requirement rows (subtotal/total rows are excluded from filtering input).
+ */
+export function filterTeachingRows(
+	rows: TeachingGridRow[],
+	bandFilter: BandFilter,
+	coverageFilter: CoverageFilter
+): TeachingGridRow[] {
+	let filtered = rows;
+
+	if (bandFilter !== 'ALL') {
+		const bandName = BAND_FILTER_MAP[bandFilter];
+		if (bandName) {
+			filtered = filtered.filter((r) => r.band === bandName);
+		}
+	}
+
+	if (coverageFilter !== 'ALL') {
+		filtered = filtered.filter((r) => r.coverageStatus === coverageFilter);
+	}
+
+	return filtered;
+}
+
+// ── Support Grid Types ──────────────────────────────────────────────────────
+
+export interface SupportDepartmentGroup {
+	department: string;
+	employees: import('../hooks/use-staffing').Employee[];
+	employeeCount: number;
+	subtotalAnnualCost: string;
+}
+
+/**
+ * Build department-grouped rows for the Support & Admin grid.
+ * Filters out teaching employees, groups by department,
+ * computes headcount and subtotal annual cost per department.
+ */
+export function buildSupportGridRows(
+	employees: import('../hooks/use-staffing').Employee[]
+): SupportDepartmentGroup[] {
+	// Filter to non-teaching employees only
+	const nonTeaching = employees.filter((emp) => !emp.isTeaching);
+
+	if (nonTeaching.length === 0) return [];
+
+	// Group by department
+	const deptMap = new Map<string, import('../hooks/use-staffing').Employee[]>();
+	for (const emp of nonTeaching) {
+		const dept = emp.department || 'Unassigned';
+		const list = deptMap.get(dept);
+		if (list) {
+			list.push(emp);
+		} else {
+			deptMap.set(dept, [emp]);
+		}
+	}
+
+	const groups: SupportDepartmentGroup[] = [];
+	for (const [department, emps] of deptMap) {
+		let subtotal = 0;
+		for (const emp of emps) {
+			subtotal += parseFloat(emp.annualCost ?? '0');
+		}
+
+		groups.push({
+			department,
+			employees: emps,
+			employeeCount: emps.length,
+			subtotalAnnualCost: String(subtotal),
+		});
+	}
+
+	return groups;
+}


### PR DESCRIPTION
## Summary

Implements Story 20-3 (#226) for Epic 20: Staffing Frontend Redesign.

- **AC-09**: New `SupportAdminGrid` component renders non-teaching employees grouped by department with collapsible headers, 8 columns (Name/Position, Role, Status badge, FTE, Start, End, Monthly Cost, Annual Cost), department subtotals, grand total row, row click selection via `staffingSelectionStore`, and double-click to open `EmployeeForm` in edit mode
- **AC-10**: Updated `EmployeeForm` with 6 new fields (`recordType`, `costMode`, `disciplineId`, `serviceProfileId`, `homeBand`, `contractEndDate`) and conditional visibility logic for AEFE recharge, no local cost, vacancy mode, teaching profile, and hidden hsaAmount
- New `buildSupportGridRows()` pure function in `staffing-workspace.ts`
- Extended `Employee` type with new fields from Epic 18/19 backend

## Files Changed

- **CREATE** `apps/web/src/components/staffing/support-admin-grid.tsx`
- **CREATE** `apps/web/src/components/staffing/support-admin-grid.test.tsx`
- **CREATE** `apps/web/src/components/staffing/employee-form.test.tsx`
- **CREATE** `apps/web/src/lib/staffing-workspace.test.ts`
- **MODIFY** `apps/web/src/components/staffing/employee-form.tsx`
- **MODIFY** `apps/web/src/lib/staffing-workspace.ts`
- **MODIFY** `apps/web/src/hooks/use-staffing.ts`
- **MODIFY** `apps/web/src/components/staffing/employee-grid.test.tsx` (type fix)
- **MODIFY** `apps/web/src/components/staffing/staff-costs-department-grid.test.tsx` (type fix)

## Test plan

- [x] 76 new/updated tests covering AC-09 and AC-10
- [x] All 397 web tests pass (zero regressions)
- [x] TypeScript typecheck clean
- [x] ESLint clean (zero errors, zero warnings)
- [x] All monetary formatting via `format-money.ts`
- [x] No hardcoded hex colors -- design tokens used throughout
- [x] WCAG AA: `role="table"`, `aria-expanded`, `aria-live` region, keyboard nav

Fixes #226
Part of Epic #221

Generated with [Claude Code](https://claude.com/claude-code)