### PR TITLE
feat(staffing): KPI Ribbon, Status Strip, and Right Panel Inspector

### DIFF
--- a/apps/web/src/components/staffing/staffing-guide-content.test.tsx
+++ b/apps/web/src/components/staffing/staffing-guide-content.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { StaffingGuideContent } from './staffing-guide-content';
+
+vi.mock('../../lib/right-panel-registry', () => ({
+	registerPanelContent: vi.fn(),
+	registerGuideContent: vi.fn(),
+}));
+
+afterEach(() => {
+	cleanup();
+});
+
+describe('StaffingGuideContent', () => {
+	it('renders contextual help content', () => {
+		render(<StaffingGuideContent />);
+
+		// Should display help text about the staffing module
+		expect(screen.getByText('Staffing Guide')).toBeDefined();
+	});
+
+	it('registers guide content with the right-panel registry', async () => {
+		const registry = await import('../../lib/right-panel-registry');
+		expect(registry.registerGuideContent).toHaveBeenCalledWith('staffing', expect.any(Function));
+	});
+
+	it('includes information about KPI metrics', () => {
+		render(<StaffingGuideContent />);
+
+		expect(screen.getByText('KPI Metrics')).toBeDefined();
+	});
+
+	it('includes information about inspector panel', () => {
+		render(<StaffingGuideContent />);
+
+		// Should mention the detail panel
+		expect(screen.getByText('Detail Panel')).toBeDefined();
+	});
+});

--- a/apps/web/src/components/staffing/staffing-guide-content.tsx
+++ b/apps/web/src/components/staffing/staffing-guide-content.tsx
@@ -1,0 +1,39 @@
+import { registerGuideContent } from '../../lib/right-panel-registry';
+
+export function StaffingGuideContent() {
+	return (
+		<div className="space-y-4 p-4">
+			<h3 className="text-lg font-semibold text-(--text-primary)">Staffing Guide</h3>
+
+			<div className="space-y-3">
+				<section>
+					<h4 className="text-sm font-medium text-(--text-secondary)">KPI Metrics</h4>
+					<p className="mt-1 text-sm text-(--text-muted)">
+						The ribbon displays key staffing metrics: total headcount, FTE gap, staff cost, HSA
+						budget, H/E ratio, and recharge cost. Values update after each calculation run.
+					</p>
+				</section>
+
+				<section>
+					<h4 className="text-sm font-medium text-(--text-secondary)">Detail Panel</h4>
+					<p className="mt-1 text-sm text-(--text-muted)">
+						Click a requirement line or employee in the grid to inspect details. The panel shows
+						driver breakdowns, assigned teachers, gap analysis, and cost splits. Use the back button
+						to return to the overview.
+					</p>
+				</section>
+
+				<section>
+					<h4 className="text-sm font-medium text-(--text-secondary)">Stale Indicators</h4>
+					<p className="mt-1 text-sm text-(--text-muted)">
+						A pulsing red dot signals that staffing data is stale and needs recalculation.
+						Downstream modules (P&amp;L) are marked with stale pills in the status strip.
+					</p>
+				</section>
+			</div>
+		</div>
+	);
+}
+
+// Register guide content at module level (side-effect import)
+registerGuideContent('staffing', StaffingGuideContent);

--- a/apps/web/src/components/staffing/staffing-inspector-content.test.tsx
+++ b/apps/web/src/components/staffing/staffing-inspector-content.test.tsx
@@ -1,0 +1,428 @@
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+// ── Mutable mock state ──────────────────────────────────────────────────────
+
+let mockSelection: {
+	type: 'REQUIREMENT_LINE' | 'SUPPORT_EMPLOYEE';
+	requirementLineId?: number;
+	employeeId?: number;
+	band?: string;
+	disciplineCode?: string;
+	department?: string;
+} | null = null;
+
+const mockClearSelection = vi.fn();
+
+vi.mock('../../stores/staffing-selection-store', () => ({
+	useStaffingSelectionStore: (selector: (state: unknown) => unknown) =>
+		selector({
+			selection: mockSelection,
+			clearSelection: mockClearSelection,
+		}),
+}));
+
+// Mock workspace context
+vi.mock('../../hooks/use-workspace-context', () => ({
+	useWorkspaceContext: () => ({
+		versionId: 42,
+		fiscalYear: 2026,
+		versionStatus: 'Draft',
+	}),
+}));
+
+// Mock versions hook
+vi.mock('../../hooks/use-versions', () => ({
+	useVersions: () => ({
+		data: {
+			data: [
+				{
+					id: 42,
+					status: 'Draft',
+					staleModules: [],
+					lastCalculatedAt: '2026-03-15T10:30:00Z',
+				},
+			],
+		},
+	}),
+}));
+
+// Mock teaching requirements
+vi.mock('../../hooks/use-staffing', () => ({
+	useTeachingRequirements: () => ({
+		data: {
+			data: [
+				{
+					id: 1,
+					band: 'MATERNELLE',
+					disciplineCode: 'FR',
+					lineLabel: 'Francais - Maternelle',
+					coverageStatus: 'COVERED',
+					requiredFteRaw: '2.50',
+					coveredFte: '2.50',
+					gapFte: '0.00',
+					assignedStaffCount: 3,
+					directCostAnnual: '360000',
+					hsaCostAnnual: '15000',
+					requiredFtePlanned: '3.00',
+					recommendedPositions: 3,
+				},
+				{
+					id: 2,
+					band: 'ELEMENTAIRE',
+					disciplineCode: 'MATH',
+					lineLabel: 'Mathematics - Elementaire',
+					coverageStatus: 'DEFICIT',
+					requiredFteRaw: '4.00',
+					coveredFte: '3.00',
+					gapFte: '-1.00',
+					assignedStaffCount: 3,
+					directCostAnnual: '480000',
+					hsaCostAnnual: '20000',
+					requiredFtePlanned: '4.00',
+					recommendedPositions: 4,
+				},
+			],
+			totals: {
+				totalFteRaw: '6.50',
+				totalFtePlanned: '7.00',
+				totalFteCovered: '5.50',
+				totalFteGap: '-1.00',
+			},
+		},
+	}),
+	useTeachingRequirementSources: () => ({
+		data: {
+			data: [
+				{
+					gradeLevel: 'PS',
+					headcount: 25,
+					sections: 1,
+					hoursPerUnit: '4.0',
+					totalWeeklyHours: '4.0',
+				},
+				{
+					gradeLevel: 'MS',
+					headcount: 28,
+					sections: 1,
+					hoursPerUnit: '4.0',
+					totalWeeklyHours: '4.0',
+				},
+			],
+		},
+	}),
+	useStaffingAssignments: () => ({
+		data: {
+			data: [
+				{
+					id: 10,
+					requirementLineId: 1,
+					employeeId: 100,
+					fteShare: '0.80',
+					hoursPerWeek: '19.2',
+					note: null,
+					source: 'MANUAL',
+				},
+				{
+					id: 11,
+					requirementLineId: 1,
+					employeeId: 101,
+					fteShare: '1.00',
+					hoursPerWeek: '24.0',
+					note: null,
+					source: 'AUTO_SUGGEST',
+				},
+			],
+		},
+	}),
+	useEmployees: () => ({
+		data: {
+			data: [
+				{
+					id: 100,
+					name: 'Marie Dupont',
+					costMode: 'LOCAL_PAYROLL',
+					department: 'Primary',
+					functionRole: 'Teacher',
+					status: 'Active',
+					baseSalary: '8000',
+					monthlyCost: '12500',
+					annualCost: '150000',
+					isTeaching: true,
+					recordType: 'TEACHER',
+					homeBand: 'MATERNELLE',
+				},
+				{
+					id: 101,
+					name: 'Jean Martin',
+					costMode: 'RECHARGE',
+					department: 'Primary',
+					functionRole: 'Teacher',
+					status: 'Active',
+					baseSalary: '9000',
+					monthlyCost: '14000',
+					annualCost: '168000',
+					isTeaching: true,
+					recordType: 'TEACHER',
+					homeBand: 'MATERNELLE',
+				},
+				{
+					id: 200,
+					name: 'Sophie Bernard',
+					costMode: 'LOCAL_PAYROLL',
+					department: 'Administration',
+					functionRole: 'Secretary',
+					status: 'Active',
+					baseSalary: '5000',
+					monthlyCost: '7500',
+					annualCost: '90000',
+					isTeaching: false,
+					recordType: 'SUPPORT',
+					homeBand: null,
+				},
+			],
+			total: 3,
+		},
+	}),
+	useEmployee: () => ({
+		data: {
+			id: 200,
+			name: 'Sophie Bernard',
+			costMode: 'LOCAL_PAYROLL',
+			department: 'Administration',
+			functionRole: 'Secretary',
+			status: 'Active',
+			baseSalary: '5000',
+			monthlyCost: '7500',
+			annualCost: '90000',
+			isTeaching: false,
+			recordType: 'SUPPORT',
+			homeBand: null,
+			joiningDate: '2024-09-01',
+			contractEndDate: null,
+		},
+	}),
+	useStaffingSummary: () => ({
+		data: {
+			fte: '42.00',
+			cost: '5400000',
+			byDepartment: [
+				{ department: 'Primary', total_cost: '3000000' },
+				{ department: 'Administration', total_cost: '2400000' },
+			],
+		},
+	}),
+}));
+
+vi.mock('../../lib/format-money', () => ({
+	formatMoney: (value: string | number, opts?: { compact?: boolean; showCurrency?: boolean }) => {
+		const num = typeof value === 'string' ? parseFloat(value) : value;
+		if (opts?.compact) {
+			if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(1)}M SAR`;
+			if (num >= 1_000) return `${(num / 1_000).toFixed(0)}K SAR`;
+			return `${num} SAR`;
+		}
+		if (opts?.showCurrency) return `SAR ${num.toLocaleString()}`;
+		return num.toLocaleString();
+	},
+}));
+
+vi.mock('../../lib/right-panel-registry', () => ({
+	registerPanelContent: vi.fn(),
+	registerGuideContent: vi.fn(),
+}));
+
+afterEach(() => {
+	cleanup();
+	mockSelection = null;
+	mockClearSelection.mockReset();
+});
+
+describe('StaffingInspectorContent', () => {
+	// Lazy import to allow mocks to be set up first
+	let StaffingInspectorContent: React.ComponentType;
+
+	beforeEach(async () => {
+		const mod = await import('./staffing-inspector-content');
+		StaffingInspectorContent = mod.StaffingInspectorContent;
+	});
+
+	// AC-14: Registration
+	it('registers panel content with the right-panel registry', async () => {
+		const registry = await import('../../lib/right-panel-registry');
+		expect(registry.registerPanelContent).toHaveBeenCalledWith('staffing', expect.any(Function));
+	});
+
+	// ── Default view (no selection) ─────────────────────────────────────────
+
+	describe('Default view (no selection)', () => {
+		it('shows workflow status card', () => {
+			mockSelection = null;
+			render(<StaffingInspectorContent />);
+
+			expect(screen.getByText(/staffing workflow/i)).toBeDefined();
+		});
+
+		it('shows quick stats', () => {
+			mockSelection = null;
+			render(<StaffingInspectorContent />);
+
+			// Should show total FTE stats
+			expect(screen.getByText('Total FTE required')).toBeDefined();
+			expect(screen.getByText('Total FTE covered')).toBeDefined();
+		});
+
+		it('shows coverage distribution', () => {
+			mockSelection = null;
+			render(<StaffingInspectorContent />);
+
+			expect(screen.getByText('Coverage distribution')).toBeDefined();
+		});
+
+		it('shows recommended actions', () => {
+			mockSelection = null;
+			render(<StaffingInspectorContent />);
+
+			expect(screen.getByText('Recommended actions')).toBeDefined();
+		});
+
+		it('shows band summary table', () => {
+			mockSelection = null;
+			render(<StaffingInspectorContent />);
+
+			expect(screen.getByText('Summary by band')).toBeDefined();
+		});
+	});
+
+	// ── Requirement line selected view ──────────────────────────────────────
+
+	describe('Requirement line selected view', () => {
+		beforeEach(() => {
+			mockSelection = {
+				type: 'REQUIREMENT_LINE',
+				requirementLineId: 1,
+				band: 'MATERNELLE',
+				disciplineCode: 'FR',
+			};
+		});
+
+		it('shows header with line label and band badge', () => {
+			render(<StaffingInspectorContent />);
+
+			expect(screen.getByText('Francais - Maternelle')).toBeDefined();
+			// Band badge text
+			expect(screen.getByText('Maternelle')).toBeDefined();
+		});
+
+		it('shows coverage status in header', () => {
+			render(<StaffingInspectorContent />);
+
+			// The coverage status badge exists in the header
+			const coverageBadges = screen.getAllByText('Covered');
+			expect(coverageBadges.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('shows driver breakdown table from sources', () => {
+			render(<StaffingInspectorContent />);
+
+			// Should show grade-level driver breakdown
+			expect(screen.getByText('PS')).toBeDefined();
+			expect(screen.getByText('MS')).toBeDefined();
+		});
+
+		it('shows assigned teachers list with costMode badges', () => {
+			render(<StaffingInspectorContent />);
+
+			expect(screen.getByText('Marie Dupont')).toBeDefined();
+			expect(screen.getByText('Jean Martin')).toBeDefined();
+			// CostMode badges
+			expect(screen.getByText(/LOCAL/i)).toBeDefined();
+			expect(screen.getByText(/RECHARGE/i)).toBeDefined();
+		});
+
+		it('shows fteShare for each assigned teacher', () => {
+			render(<StaffingInspectorContent />);
+
+			expect(screen.getByText('0.80')).toBeDefined();
+			expect(screen.getByText('1.00')).toBeDefined();
+		});
+
+		it('shows gap analysis card', () => {
+			render(<StaffingInspectorContent />);
+
+			expect(screen.getByText(/gap analysis/i)).toBeDefined();
+		});
+
+		it('shows cost split card', () => {
+			render(<StaffingInspectorContent />);
+
+			expect(screen.getByText(/cost split/i)).toBeDefined();
+		});
+
+		it('shows back button that returns to default view', () => {
+			render(<StaffingInspectorContent />);
+
+			const backButton = screen.getByRole('button', { name: /back/i });
+			expect(backButton).toBeDefined();
+
+			fireEvent.click(backButton);
+			expect(mockClearSelection).toHaveBeenCalled();
+		});
+
+		it('applies animate-inspector-slide-in transition', () => {
+			const { container } = render(<StaffingInspectorContent />);
+
+			const animated = container.querySelector('.animate-inspector-slide-in');
+			expect(animated).not.toBeNull();
+		});
+	});
+
+	// ── Support employee selected view ──────────────────────────────────────
+
+	describe('Support employee selected view', () => {
+		beforeEach(() => {
+			mockSelection = {
+				type: 'SUPPORT_EMPLOYEE',
+				employeeId: 200,
+				department: 'Administration',
+			};
+		});
+
+		it('shows employee header with name', () => {
+			render(<StaffingInspectorContent />);
+
+			expect(screen.getByText('Sophie Bernard')).toBeDefined();
+		});
+
+		it('shows employment details', () => {
+			render(<StaffingInspectorContent />);
+
+			expect(screen.getByText(/secretary/i)).toBeDefined();
+			expect(screen.getByText(/administration/i)).toBeDefined();
+		});
+
+		it('shows cost summary', () => {
+			render(<StaffingInspectorContent />);
+
+			// Should show cost summary section
+			expect(screen.getByText('Cost summary')).toBeDefined();
+		});
+
+		it('shows back button that clears selection', () => {
+			render(<StaffingInspectorContent />);
+
+			const backButton = screen.getByRole('button', { name: /back/i });
+			expect(backButton).toBeDefined();
+
+			fireEvent.click(backButton);
+			expect(mockClearSelection).toHaveBeenCalled();
+		});
+
+		it('applies animate-inspector-slide-in transition', () => {
+			const { container } = render(<StaffingInspectorContent />);
+
+			const animated = container.querySelector('.animate-inspector-slide-in');
+			expect(animated).not.toBeNull();
+		});
+	});
+});

--- a/apps/web/src/components/staffing/staffing-inspector-content.tsx
+++ b/apps/web/src/components/staffing/staffing-inspector-content.tsx
@@ -1,0 +1,588 @@
+import { useMemo } from 'react';
+import { ArrowLeft, ShieldCheck } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { formatMoney } from '../../lib/format-money';
+import { registerPanelContent } from '../../lib/right-panel-registry';
+import { useStaffingSelectionStore } from '../../stores/staffing-selection-store';
+import { useWorkspaceContext } from '../../hooks/use-workspace-context';
+import {
+	useTeachingRequirements,
+	useTeachingRequirementSources,
+	useStaffingAssignments,
+	useEmployees,
+	useEmployee,
+	type Employee,
+} from '../../hooks/use-staffing';
+
+// ── Band badge styles ────────────────────────────────────────────────────────
+
+const BAND_BADGE_STYLES: Record<string, string> = {
+	MATERNELLE: 'bg-(--badge-maternelle-bg) text-(--badge-maternelle)',
+	ELEMENTAIRE: 'bg-(--badge-elementaire-bg) text-(--badge-elementaire)',
+	COLLEGE: 'bg-(--badge-college-bg) text-(--badge-college)',
+	LYCEE: 'bg-(--badge-lycee-bg) text-(--badge-lycee)',
+};
+
+const BAND_LABELS: Record<string, string> = {
+	MATERNELLE: 'Maternelle',
+	ELEMENTAIRE: 'Elementaire',
+	COLLEGE: 'College',
+	LYCEE: 'Lycee',
+};
+
+const COVERAGE_STATUS_STYLES: Record<string, { bg: string; text: string; label: string }> = {
+	COVERED: { bg: 'bg-(--color-success-bg)', text: 'text-(--color-success)', label: 'Covered' },
+	DEFICIT: { bg: 'bg-(--color-error-bg)', text: 'text-(--color-error)', label: 'Deficit' },
+	SURPLUS: { bg: 'bg-(--color-warning-bg)', text: 'text-(--color-warning)', label: 'Surplus' },
+	UNCOVERED: { bg: 'bg-(--color-error-bg)', text: 'text-(--color-error)', label: 'Uncovered' },
+};
+
+const COST_MODE_STYLES: Record<string, { bg: string; text: string; label: string }> = {
+	LOCAL_PAYROLL: {
+		bg: 'bg-(--accent-50)',
+		text: 'text-(--accent-700)',
+		label: 'LOCAL',
+	},
+	RECHARGE: {
+		bg: 'bg-(--color-warning-bg)',
+		text: 'text-(--color-warning)',
+		label: 'RECHARGE',
+	},
+	NO_COST: {
+		bg: 'bg-(--workspace-bg-muted)',
+		text: 'text-(--text-muted)',
+		label: 'NO_COST',
+	},
+};
+
+// ── Default view ─────────────────────────────────────────────────────────────
+
+function InspectorDefaultView() {
+	const { versionId } = useWorkspaceContext();
+	const { data: reqData } = useTeachingRequirements(versionId);
+
+	const totals = reqData?.totals;
+	const lines = useMemo(() => reqData?.data ?? [], [reqData?.data]);
+
+	const coverageDist = useMemo(() => {
+		const dist = { covered: 0, deficit: 0, surplus: 0, uncovered: 0 };
+		for (const line of lines) {
+			const status = line.coverageStatus.toLowerCase() as keyof typeof dist;
+			if (status in dist) {
+				dist[status]++;
+			}
+		}
+		return dist;
+	}, [lines]);
+
+	const bandSummary = useMemo(() => {
+		const bands = new Map<string, { count: number; fteRaw: number; covered: number }>();
+		for (const line of lines) {
+			const existing = bands.get(line.band) ?? { count: 0, fteRaw: 0, covered: 0 };
+			existing.count++;
+			existing.fteRaw += parseFloat(line.requiredFteRaw);
+			existing.covered += parseFloat(line.coveredFte);
+			bands.set(line.band, existing);
+		}
+		return Array.from(bands.entries()).map(([band, data]) => ({
+			band,
+			label: BAND_LABELS[band] ?? band,
+			...data,
+		}));
+	}, [lines]);
+
+	return (
+		<div className="space-y-5">
+			{/* Workflow status card */}
+			<div
+				className={cn(
+					'rounded-xl border border-(--workspace-border) bg-(--workspace-bg-card) px-4 py-4',
+					'border-l-[3px] border-l-(--accent-500)'
+				)}
+			>
+				<div className="flex items-start gap-3">
+					<span className="mt-0.5 inline-flex h-9 w-9 items-center justify-center rounded-xl bg-(--accent-50)">
+						<ShieldCheck className="h-4 w-4 text-(--accent-700)" aria-hidden="true" />
+					</span>
+					<div className="space-y-1">
+						<p className="text-(--text-xs) font-semibold uppercase tracking-[0.08em] text-(--text-muted)">
+							Staffing workflow
+						</p>
+						<p className="text-sm text-(--text-secondary)">
+							Review teaching requirements and coverage, then assign teachers to fill gaps.
+						</p>
+					</div>
+				</div>
+			</div>
+
+			{/* Quick stats */}
+			<div className="grid gap-3 md:grid-cols-2">
+				<div className="rounded-xl border border-(--workspace-border) bg-(--workspace-bg-card) px-4 py-3">
+					<p className="text-(--text-xs) font-semibold uppercase tracking-[0.08em] text-(--text-muted)">
+						Total FTE required
+					</p>
+					<p className="mt-2 text-xl font-semibold text-(--text-primary)">
+						{totals?.totalFteRaw ?? '0'}
+					</p>
+				</div>
+				<div className="rounded-xl border border-(--workspace-border) bg-(--workspace-bg-card) px-4 py-3">
+					<p className="text-(--text-xs) font-semibold uppercase tracking-[0.08em] text-(--text-muted)">
+						Total FTE covered
+					</p>
+					<p className="mt-2 text-xl font-semibold text-(--text-primary)">
+						{totals?.totalFteCovered ?? '0'}
+					</p>
+				</div>
+			</div>
+
+			{/* Coverage distribution */}
+			<div>
+				<h4 className="mb-2 text-(--text-xs) font-semibold uppercase tracking-[0.06em] text-(--text-muted)">
+					Coverage distribution
+				</h4>
+				<div className="overflow-hidden rounded-lg border border-(--workspace-border)">
+					<div className="divide-y divide-(--workspace-border)">
+						{Object.entries(coverageDist).map(([status, count]) => (
+							<div key={status} className="flex items-center justify-between px-3 py-2">
+								<span className="text-sm capitalize text-(--text-secondary)">{status}</span>
+								<span className="font-[family-name:var(--font-mono)] text-sm tabular-nums text-(--text-primary)">
+									{count}
+								</span>
+							</div>
+						))}
+					</div>
+				</div>
+			</div>
+
+			{/* Recommended actions */}
+			<div>
+				<h4 className="mb-2 text-(--text-xs) font-semibold uppercase tracking-[0.06em] text-(--text-muted)">
+					Recommended actions
+				</h4>
+				<div className="rounded-lg border border-(--workspace-border) bg-(--workspace-bg-card) p-3">
+					{coverageDist.deficit > 0 || coverageDist.uncovered > 0 ? (
+						<p className="text-sm text-(--text-secondary)">
+							{coverageDist.deficit + coverageDist.uncovered} requirement lines need teacher
+							assignments. Use Auto-Suggest or assign manually.
+						</p>
+					) : (
+						<p className="text-sm text-(--text-muted)">
+							All requirement lines are covered. No immediate action needed.
+						</p>
+					)}
+				</div>
+			</div>
+
+			{/* Band summary */}
+			<div>
+				<h4 className="mb-2 text-(--text-xs) font-semibold uppercase tracking-[0.06em] text-(--text-muted)">
+					Summary by band
+				</h4>
+				<div className="overflow-hidden rounded-lg border border-(--workspace-border)">
+					<table className="w-full text-sm">
+						<thead>
+							<tr className="bg-(--workspace-bg-muted)">
+								<th className="px-3 py-1.5 text-left text-(--text-xs) font-medium uppercase tracking-wider text-(--text-muted)">
+									Band
+								</th>
+								<th className="px-3 py-1.5 text-right text-(--text-xs) font-medium uppercase tracking-wider text-(--text-muted)">
+									Lines
+								</th>
+								<th className="px-3 py-1.5 text-right text-(--text-xs) font-medium uppercase tracking-wider text-(--text-muted)">
+									FTE
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{bandSummary.map((row) => (
+								<tr key={row.band} className="border-t border-(--workspace-border)">
+									<td className="px-3 py-1.5 font-medium">{row.label}</td>
+									<td className="px-3 py-1.5 text-right font-[family-name:var(--font-mono)] tabular-nums">
+										{row.count}
+									</td>
+									<td className="px-3 py-1.5 text-right font-[family-name:var(--font-mono)] tabular-nums">
+										{row.fteRaw.toFixed(2)}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ── Requirement line view ────────────────────────────────────────────────────
+
+function InspectorRequirementView({
+	requirementLineId,
+	band,
+}: {
+	requirementLineId: number;
+	band: string;
+}) {
+	const { versionId } = useWorkspaceContext();
+	const clearSelection = useStaffingSelectionStore((state) => state.clearSelection);
+	const { data: reqData } = useTeachingRequirements(versionId);
+	const { data: sourcesData } = useTeachingRequirementSources(versionId, requirementLineId);
+	const { data: assignmentsData } = useStaffingAssignments(versionId);
+	const { data: employeesData } = useEmployees(versionId);
+
+	const line = useMemo(
+		() => reqData?.data.find((l) => l.id === requirementLineId) ?? null,
+		[reqData?.data, requirementLineId]
+	);
+
+	const lineAssignments = useMemo(
+		() => (assignmentsData?.data ?? []).filter((a) => a.requirementLineId === requirementLineId),
+		[assignmentsData?.data, requirementLineId]
+	);
+
+	const employeeMap = useMemo(() => {
+		const map = new Map<number, Employee>();
+		for (const emp of employeesData?.data ?? []) {
+			map.set(emp.id, emp);
+		}
+		return map;
+	}, [employeesData?.data]);
+
+	if (!line) return null;
+
+	const sources = sourcesData?.data ?? [];
+	const defaultCoverageStyle = {
+		bg: 'bg-(--color-success-bg)',
+		text: 'text-(--color-success)',
+		label: 'Covered',
+	};
+	const coverageStyle = COVERAGE_STATUS_STYLES[line.coverageStatus] ?? defaultCoverageStyle;
+	const bandLabel = BAND_LABELS[band] ?? band;
+	const bandBadgeStyle = BAND_BADGE_STYLES[band] ?? '';
+
+	const gapValue = parseFloat(line.gapFte);
+	const directCost = parseFloat(line.directCostAnnual);
+	const hsaCost = parseFloat(line.hsaCostAnnual);
+	const totalCost = directCost + hsaCost;
+
+	return (
+		<div className="space-y-4">
+			{/* Header with back button */}
+			<div className="flex items-center gap-2">
+				<button
+					type="button"
+					onClick={clearSelection}
+					className={cn(
+						'rounded-md p-1 text-(--text-muted) transition-colors duration-(--duration-fast)',
+						'hover:bg-(--workspace-bg-muted) hover:text-(--text-primary)'
+					)}
+					aria-label="Back to overview"
+				>
+					<ArrowLeft className="h-4 w-4" />
+				</button>
+				<span
+					className={cn('rounded-sm px-1.5 py-0.5 text-(--text-xs) font-medium', bandBadgeStyle)}
+				>
+					{bandLabel}
+				</span>
+				<h3 className="font-[family-name:var(--font-display)] text-lg font-semibold text-(--text-primary)">
+					{line.lineLabel}
+				</h3>
+				<span
+					className={cn(
+						'rounded-full px-2 py-0.5 text-(--text-xs) font-semibold',
+						coverageStyle.bg,
+						coverageStyle.text
+					)}
+				>
+					{coverageStyle.label}
+				</span>
+			</div>
+
+			{/* Driver Breakdown table */}
+			<div>
+				<h4 className="mb-2 text-(--text-xs) font-semibold uppercase tracking-[0.06em] text-(--text-muted)">
+					Driver breakdown
+				</h4>
+				<div className="overflow-hidden rounded-lg border border-(--workspace-border)">
+					<table className="w-full text-sm">
+						<thead>
+							<tr className="bg-(--workspace-bg-muted)">
+								<th className="px-3 py-1.5 text-left text-(--text-xs) font-medium uppercase tracking-wider text-(--text-muted)">
+									Grade
+								</th>
+								<th className="px-3 py-1.5 text-right text-(--text-xs) font-medium uppercase tracking-wider text-(--text-muted)">
+									Headcount
+								</th>
+								<th className="px-3 py-1.5 text-right text-(--text-xs) font-medium uppercase tracking-wider text-(--text-muted)">
+									Sections
+								</th>
+								<th className="px-3 py-1.5 text-right text-(--text-xs) font-medium uppercase tracking-wider text-(--text-muted)">
+									Hrs/unit
+								</th>
+								<th className="px-3 py-1.5 text-right text-(--text-xs) font-medium uppercase tracking-wider text-(--text-muted)">
+									Total Hrs/w
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{sources.map((src) => (
+								<tr key={src.gradeLevel} className="border-t border-(--workspace-border)">
+									<td className="px-3 py-1.5 font-medium">{src.gradeLevel}</td>
+									<td className="px-3 py-1.5 text-right font-[family-name:var(--font-mono)] tabular-nums">
+										{src.headcount}
+									</td>
+									<td className="px-3 py-1.5 text-right font-[family-name:var(--font-mono)] tabular-nums">
+										{src.sections}
+									</td>
+									<td className="px-3 py-1.5 text-right font-[family-name:var(--font-mono)] tabular-nums">
+										{src.hoursPerUnit}
+									</td>
+									<td className="px-3 py-1.5 text-right font-[family-name:var(--font-mono)] tabular-nums">
+										{src.totalWeeklyHours}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			</div>
+
+			{/* Assigned Teachers list */}
+			<div>
+				<h4 className="mb-2 text-(--text-xs) font-semibold uppercase tracking-[0.06em] text-(--text-muted)">
+					Assigned teachers
+				</h4>
+				<div className="space-y-2">
+					{lineAssignments.map((assignment) => {
+						const emp = employeeMap.get(assignment.employeeId);
+						const defaultCostMode = {
+							bg: 'bg-(--accent-50)',
+							text: 'text-(--accent-700)',
+							label: 'LOCAL',
+						};
+						const costModeStyle =
+							COST_MODE_STYLES[emp?.costMode ?? 'LOCAL_PAYROLL'] ?? defaultCostMode;
+
+						return (
+							<div
+								key={assignment.id}
+								className="flex items-center justify-between rounded-lg border border-(--workspace-border) bg-(--workspace-bg-card) px-3 py-2"
+							>
+								<div className="flex items-center gap-2">
+									<span className="text-sm font-medium text-(--text-primary)">
+										{emp?.name ?? `Employee #${assignment.employeeId}`}
+									</span>
+									<span
+										className={cn(
+											'rounded-sm px-1.5 py-0.5 text-(--text-xs) font-medium',
+											costModeStyle.bg,
+											costModeStyle.text
+										)}
+									>
+										{costModeStyle.label}
+									</span>
+								</div>
+								<span className="font-[family-name:var(--font-mono)] text-sm tabular-nums text-(--text-secondary)">
+									{assignment.fteShare}
+								</span>
+							</div>
+						);
+					})}
+					{lineAssignments.length === 0 && (
+						<p className="text-sm text-(--text-muted)">No teachers assigned yet.</p>
+					)}
+				</div>
+			</div>
+
+			{/* Gap Analysis card */}
+			<div>
+				<h4 className="mb-2 text-(--text-xs) font-semibold uppercase tracking-[0.06em] text-(--text-muted)">
+					Gap analysis
+				</h4>
+				<div className="space-y-2 rounded-lg border border-(--workspace-border) bg-(--workspace-bg-card) p-3">
+					<div className="flex items-center justify-between">
+						<span className="text-sm text-(--text-secondary)">Raw need</span>
+						<span className="font-[family-name:var(--font-mono)] text-sm tabular-nums text-(--text-primary)">
+							{line.requiredFteRaw}
+						</span>
+					</div>
+					<div className="flex items-center justify-between">
+						<span className="text-sm text-(--text-secondary)">Planned need</span>
+						<span className="font-[family-name:var(--font-mono)] text-sm tabular-nums text-(--text-primary)">
+							{line.requiredFtePlanned}
+						</span>
+					</div>
+					<div className="flex items-center justify-between">
+						<span className="text-sm text-(--text-secondary)">Covered</span>
+						<span className="font-[family-name:var(--font-mono)] text-sm tabular-nums text-(--text-primary)">
+							{line.coveredFte}
+						</span>
+					</div>
+					<div className="flex items-center justify-between">
+						<span className="text-sm text-(--text-secondary)">Gap</span>
+						<span
+							className={cn(
+								'font-[family-name:var(--font-mono)] text-sm tabular-nums font-semibold',
+								gapValue < 0 && 'text-(--color-error)',
+								gapValue > 0 && 'text-(--color-warning)',
+								gapValue === 0 && 'text-(--color-success)'
+							)}
+						>
+							{line.gapFte}
+						</span>
+					</div>
+					{gapValue < 0 && (
+						<p className="mt-1 text-(--text-xs) text-(--text-muted)">
+							Hiring recommendation: {Math.ceil(Math.abs(gapValue))} additional position(s)
+						</p>
+					)}
+				</div>
+			</div>
+
+			{/* Cost Split card */}
+			<div>
+				<h4 className="mb-2 text-(--text-xs) font-semibold uppercase tracking-[0.06em] text-(--text-muted)">
+					Cost split
+				</h4>
+				<div className="space-y-2 rounded-lg border border-(--workspace-border) bg-(--workspace-bg-card) p-3">
+					<div className="flex items-center justify-between">
+						<span className="text-sm text-(--text-secondary)">Direct payroll</span>
+						<span className="font-[family-name:var(--font-mono)] text-sm tabular-nums text-(--text-primary)">
+							{formatMoney(directCost, { showCurrency: true })}
+						</span>
+					</div>
+					<div className="flex items-center justify-between">
+						<span className="text-sm text-(--text-secondary)">HSA cost</span>
+						<span className="font-[family-name:var(--font-mono)] text-sm tabular-nums text-(--text-primary)">
+							{formatMoney(hsaCost, { showCurrency: true })}
+						</span>
+					</div>
+					<div className="flex items-center justify-between border-t border-(--workspace-border) pt-2">
+						<span className="text-sm font-semibold text-(--text-primary)">Total loaded cost</span>
+						<span className="font-[family-name:var(--font-mono)] text-sm tabular-nums font-semibold text-(--text-primary)">
+							{formatMoney(totalCost, { showCurrency: true })}
+						</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ── Support employee view ────────────────────────────────────────────────────
+
+function InspectorSupportView({ employeeId }: { employeeId: number }) {
+	const { versionId } = useWorkspaceContext();
+	const clearSelection = useStaffingSelectionStore((state) => state.clearSelection);
+	const { data: empData } = useEmployee(versionId, employeeId);
+
+	if (!empData) return null;
+
+	return (
+		<div className="space-y-4">
+			{/* Header with back button */}
+			<div className="flex items-center gap-2">
+				<button
+					type="button"
+					onClick={clearSelection}
+					className={cn(
+						'rounded-md p-1 text-(--text-muted) transition-colors duration-(--duration-fast)',
+						'hover:bg-(--workspace-bg-muted) hover:text-(--text-primary)'
+					)}
+					aria-label="Back to overview"
+				>
+					<ArrowLeft className="h-4 w-4" />
+				</button>
+				<h3 className="font-[family-name:var(--font-display)] text-lg font-semibold text-(--text-primary)">
+					{empData.name}
+				</h3>
+			</div>
+
+			{/* Employment details */}
+			<div>
+				<h4 className="mb-2 text-(--text-xs) font-semibold uppercase tracking-[0.06em] text-(--text-muted)">
+					Employment details
+				</h4>
+				<div className="space-y-2 rounded-lg border border-(--workspace-border) bg-(--workspace-bg-card) p-3">
+					<div className="flex items-center justify-between">
+						<span className="text-sm text-(--text-secondary)">Role</span>
+						<span className="text-sm text-(--text-primary)">{empData.functionRole}</span>
+					</div>
+					<div className="flex items-center justify-between">
+						<span className="text-sm text-(--text-secondary)">Department</span>
+						<span className="text-sm text-(--text-primary)">{empData.department}</span>
+					</div>
+					<div className="flex items-center justify-between">
+						<span className="text-sm text-(--text-secondary)">Status</span>
+						<span className="text-sm text-(--text-primary)">{empData.status}</span>
+					</div>
+					{empData.joiningDate && (
+						<div className="flex items-center justify-between">
+							<span className="text-sm text-(--text-secondary)">Joining date</span>
+							<span className="text-sm text-(--text-primary)">{empData.joiningDate}</span>
+						</div>
+					)}
+				</div>
+			</div>
+
+			{/* Cost summary */}
+			<div>
+				<h4 className="mb-2 text-(--text-xs) font-semibold uppercase tracking-[0.06em] text-(--text-muted)">
+					Cost summary
+				</h4>
+				<div className="space-y-2 rounded-lg border border-(--workspace-border) bg-(--workspace-bg-card) p-3">
+					{empData.monthlyCost && (
+						<div className="flex items-center justify-between">
+							<span className="text-sm text-(--text-secondary)">Monthly cost</span>
+							<span className="font-[family-name:var(--font-mono)] text-sm tabular-nums text-(--text-primary)">
+								{formatMoney(empData.monthlyCost, { showCurrency: true })}
+							</span>
+						</div>
+					)}
+					{empData.annualCost && (
+						<div className="flex items-center justify-between">
+							<span className="text-sm text-(--text-secondary)">Annual cost</span>
+							<span className="font-[family-name:var(--font-mono)] text-sm tabular-nums text-(--text-primary)">
+								{formatMoney(empData.annualCost, { showCurrency: true })}
+							</span>
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ── Main inspector content ───────────────────────────────────────────────────
+
+export function StaffingInspectorContent() {
+	const selection = useStaffingSelectionStore((state) => state.selection);
+
+	if (selection?.type === 'REQUIREMENT_LINE') {
+		return (
+			<div key={selection.requirementLineId} className="animate-inspector-slide-in">
+				<InspectorRequirementView
+					requirementLineId={selection.requirementLineId}
+					band={selection.band}
+				/>
+			</div>
+		);
+	}
+
+	if (selection?.type === 'SUPPORT_EMPLOYEE') {
+		return (
+			<div key={selection.employeeId} className="animate-inspector-slide-in">
+				<InspectorSupportView employeeId={selection.employeeId} />
+			</div>
+		);
+	}
+
+	return (
+		<div className="animate-inspector-crossfade">
+			<InspectorDefaultView />
+		</div>
+	);
+}
+
+// Register panel content at module level (side-effect import)
+registerPanelContent('staffing', StaffingInspectorContent);

--- a/apps/web/src/components/staffing/staffing-kpi-ribbon.test.tsx
+++ b/apps/web/src/components/staffing/staffing-kpi-ribbon.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { StaffingKpiRibbonV2, type StaffingKpiRibbonV2Props } from './staffing-kpi-ribbon';
+
+// Mock the Counter component to avoid animation timing issues
+vi.mock('../shared/counter', () => ({
+	Counter: ({
+		value,
+		formatter,
+		className,
+	}: {
+		value: number;
+		formatter: (v: number) => string;
+		className?: string;
+	}) => (
+		<span className={className} data-testid="counter">
+			{formatter(value)}
+		</span>
+	),
+}));
+
+vi.mock('../../lib/format-money', () => ({
+	formatMoney: (value: string | number, opts?: { compact?: boolean; showCurrency?: boolean }) => {
+		const num = typeof value === 'string' ? parseFloat(value) : value;
+		if (opts?.compact) {
+			if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(1)}M SAR`;
+			if (num >= 1_000) return `${(num / 1_000).toFixed(0)}K SAR`;
+			return `${num} SAR`;
+		}
+		return String(num);
+	},
+}));
+
+afterEach(() => {
+	cleanup();
+});
+
+const defaultProps: StaffingKpiRibbonV2Props = {
+	totalHeadcount: 42,
+	fteGap: -0.5,
+	staffCost: 5400000,
+	hsaBudget: 180000,
+	heRatio: 8.5,
+	rechargeCost: 360000,
+	isStale: false,
+};
+
+describe('StaffingKpiRibbonV2', () => {
+	it('renders all 6 KPI cards with correct labels', () => {
+		render(<StaffingKpiRibbonV2 {...defaultProps} />);
+
+		expect(screen.getByText('Total Headcount')).toBeDefined();
+		expect(screen.getByText('FTE Gap')).toBeDefined();
+		expect(screen.getByText('Staff Cost')).toBeDefined();
+		expect(screen.getByText('HSA Budget')).toBeDefined();
+		expect(screen.getByText('H/E Ratio')).toBeDefined();
+		expect(screen.getByText('Recharge Cost')).toBeDefined();
+	});
+
+	it('displays formatted headcount value', () => {
+		render(<StaffingKpiRibbonV2 {...defaultProps} />);
+
+		expect(screen.getByText('42')).toBeDefined();
+	});
+
+	it('displays compact SAR values for monetary KPIs', () => {
+		render(<StaffingKpiRibbonV2 {...defaultProps} />);
+
+		// Staff Cost should show compact SAR
+		expect(screen.getByText('5.4M SAR')).toBeDefined();
+		// HSA Budget
+		expect(screen.getByText('180K SAR')).toBeDefined();
+		// Recharge Cost
+		expect(screen.getByText('360K SAR')).toBeDefined();
+	});
+
+	it('displays H/E Ratio with 2 decimal places', () => {
+		render(<StaffingKpiRibbonV2 {...defaultProps} />);
+
+		expect(screen.getByText('8.50')).toBeDefined();
+	});
+
+	it('displays FTE Gap value', () => {
+		render(<StaffingKpiRibbonV2 {...defaultProps} />);
+
+		expect(screen.getByText('-0.50')).toBeDefined();
+	});
+
+	// AC-12: FTE Gap card dynamic border color
+	it('shows green border on FTE Gap card when balanced (|gap| <= 0.25)', () => {
+		const { container } = render(<StaffingKpiRibbonV2 {...defaultProps} fteGap={0.1} />);
+
+		const fteGapCard = container.querySelector('[data-kpi="fteGap"]');
+		expect(fteGapCard).not.toBeNull();
+		expect(fteGapCard!.className).toContain('border-l-');
+		// Should contain the success/green color token
+		expect(fteGapCard!.className).toMatch(/color-success|kpi-accent-success/);
+	});
+
+	it('shows red border on FTE Gap card when deficit (gap < -0.25)', () => {
+		const { container } = render(<StaffingKpiRibbonV2 {...defaultProps} fteGap={-1.0} />);
+
+		const fteGapCard = container.querySelector('[data-kpi="fteGap"]');
+		expect(fteGapCard).not.toBeNull();
+		expect(fteGapCard!.className).toMatch(/color-error|kpi-accent-error/);
+	});
+
+	it('shows amber border on FTE Gap card when surplus (gap > 0.25)', () => {
+		const { container } = render(<StaffingKpiRibbonV2 {...defaultProps} fteGap={1.0} />);
+
+		const fteGapCard = container.querySelector('[data-kpi="fteGap"]');
+		expect(fteGapCard).not.toBeNull();
+		expect(fteGapCard!.className).toMatch(/color-warning|kpi-accent-warning/);
+	});
+
+	// AC-12: Stale indicator
+	it('shows stale indicator with pulsing dot when isStale is true', () => {
+		render(<StaffingKpiRibbonV2 {...defaultProps} isStale />);
+
+		expect(screen.getByRole('status')).toBeDefined();
+		const staleText = screen.getByText(/Stale/);
+		expect(staleText).toBeDefined();
+	});
+
+	it('hides stale indicator when isStale is false', () => {
+		render(<StaffingKpiRibbonV2 {...defaultProps} isStale={false} />);
+
+		expect(screen.queryByText(/Stale/)).toBeNull();
+	});
+
+	// AC-12: Grid responsive layout
+	it('uses responsive grid cols (grid-cols-2 lg:grid-cols-3 xl:grid-cols-6)', () => {
+		const { container } = render(<StaffingKpiRibbonV2 {...defaultProps} />);
+
+		const grid = container.querySelector('[role="region"]');
+		expect(grid).not.toBeNull();
+		expect(grid!.className).toContain('grid-cols-2');
+		expect(grid!.className).toContain('lg:grid-cols-3');
+		expect(grid!.className).toContain('xl:grid-cols-6');
+	});
+
+	// AC-12: Staggered animation delay
+	it('applies staggered 60ms animation delays to KPI cards', () => {
+		const { container } = render(<StaffingKpiRibbonV2 {...defaultProps} />);
+
+		const cards = container.querySelectorAll('[data-kpi]');
+		expect(cards.length).toBe(6);
+
+		cards.forEach((card, i) => {
+			expect((card as HTMLElement).style.animationDelay).toBe(`${i * 60}ms`);
+		});
+	});
+
+	// AC-12: Counter component used for animated values
+	it('uses Counter components for all 6 values', () => {
+		render(<StaffingKpiRibbonV2 {...defaultProps} />);
+
+		const counters = screen.getAllByTestId('counter');
+		expect(counters.length).toBe(6);
+	});
+
+	it('renders zero values without crashing', () => {
+		render(
+			<StaffingKpiRibbonV2
+				totalHeadcount={0}
+				fteGap={0}
+				staffCost={0}
+				hsaBudget={0}
+				heRatio={0}
+				rechargeCost={0}
+				isStale={false}
+			/>
+		);
+
+		expect(screen.getByText('Total Headcount')).toBeDefined();
+	});
+
+	it('has accessible region landmark', () => {
+		render(<StaffingKpiRibbonV2 {...defaultProps} />);
+
+		expect(screen.getByRole('region', { name: /staffing.*key.*performance/i })).toBeDefined();
+	});
+});

--- a/apps/web/src/components/staffing/staffing-kpi-ribbon.tsx
+++ b/apps/web/src/components/staffing/staffing-kpi-ribbon.tsx
@@ -1,0 +1,198 @@
+import {
+	ArrowUpRight,
+	BarChart3,
+	Clock,
+	DollarSign,
+	TrendingDown,
+	TrendingUp,
+	Users,
+} from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { Counter } from '../shared/counter';
+import { formatMoney } from '../../lib/format-money';
+
+export type StaffingKpiRibbonV2Props = {
+	totalHeadcount: number;
+	fteGap: number;
+	staffCost: number;
+	hsaBudget: number;
+	heRatio: number;
+	rechargeCost: number;
+	isStale: boolean;
+};
+
+type KpiDef = {
+	label: string;
+	key: keyof Omit<StaffingKpiRibbonV2Props, 'isStale'>;
+	icon: typeof Users;
+	formatter: (v: number) => string;
+	getBorderClass?: (value: number) => string;
+	getIconBgClass?: (value: number) => string;
+	getIconColorClass?: (value: number) => string;
+};
+
+function fteGapBorderClass(gap: number): string {
+	if (gap < -0.25) return 'border-l-(--color-error)';
+	if (gap > 0.25) return 'border-l-(--color-warning)';
+	return 'border-l-(--color-success)';
+}
+
+function fteGapIconBgClass(gap: number): string {
+	if (gap < -0.25) return 'bg-(--color-error-bg)';
+	if (gap > 0.25) return 'bg-(--color-warning-bg)';
+	return 'bg-(--color-success-bg)';
+}
+
+function fteGapIconColorClass(gap: number): string {
+	if (gap < -0.25) return 'text-(--color-error)';
+	if (gap > 0.25) return 'text-(--color-warning)';
+	return 'text-(--color-success)';
+}
+
+const kpiDefs: KpiDef[] = [
+	{
+		label: 'Total Headcount',
+		key: 'totalHeadcount',
+		icon: Users,
+		formatter: (v: number) => v.toLocaleString(),
+	},
+	{
+		label: 'FTE Gap',
+		key: 'fteGap',
+		icon: TrendingUp,
+		formatter: (v: number) => v.toFixed(2),
+		getBorderClass: fteGapBorderClass,
+		getIconBgClass: fteGapIconBgClass,
+		getIconColorClass: fteGapIconColorClass,
+	},
+	{
+		label: 'Staff Cost',
+		key: 'staffCost',
+		icon: DollarSign,
+		formatter: (v: number) => formatMoney(v, { compact: true, showCurrency: true }),
+	},
+	{
+		label: 'HSA Budget',
+		key: 'hsaBudget',
+		icon: Clock,
+		formatter: (v: number) => formatMoney(v, { compact: true, showCurrency: true }),
+	},
+	{
+		label: 'H/E Ratio',
+		key: 'heRatio',
+		icon: BarChart3,
+		formatter: (v: number) => v.toFixed(2),
+	},
+	{
+		label: 'Recharge Cost',
+		key: 'rechargeCost',
+		icon: ArrowUpRight,
+		formatter: (v: number) => formatMoney(v, { compact: true, showCurrency: true }),
+	},
+];
+
+function getFteGapIcon(gap: number) {
+	return gap < 0 ? TrendingDown : TrendingUp;
+}
+
+export function StaffingKpiRibbonV2({
+	totalHeadcount,
+	fteGap,
+	staffCost,
+	hsaBudget,
+	heRatio,
+	rechargeCost,
+	isStale,
+}: StaffingKpiRibbonV2Props) {
+	const values: Record<string, number> = {
+		totalHeadcount,
+		fteGap,
+		staffCost,
+		hsaBudget,
+		heRatio,
+		rechargeCost,
+	};
+
+	return (
+		<>
+			<div
+				className="grid grid-cols-2 gap-3 lg:grid-cols-3 xl:grid-cols-6"
+				role="region"
+				aria-label="Staffing key performance indicators"
+			>
+				{kpiDefs.map((kpi, i) => {
+					const value = values[kpi.key] ?? 0;
+					const borderClass = kpi.getBorderClass
+						? kpi.getBorderClass(value)
+						: 'border-l-(--kpi-accent-default)';
+					const iconBgClass = kpi.getIconBgClass ? kpi.getIconBgClass(value) : 'bg-(--accent-50)';
+					const iconColorClass = kpi.getIconColorClass
+						? kpi.getIconColorClass(value)
+						: 'text-(--accent-500)';
+
+					const Icon = kpi.key === 'fteGap' ? getFteGapIcon(value) : kpi.icon;
+
+					return (
+						<div
+							key={kpi.key}
+							data-kpi={kpi.key}
+							className={cn(
+								'animate-kpi-enter relative overflow-hidden',
+								'rounded-xl',
+								'border border-(--workspace-border)',
+								'shadow-(--shadow-card)',
+								'bg-(--workspace-bg-card) p-3',
+								'border-l-[3px]',
+								borderClass
+							)}
+							style={{ animationDelay: `${i * 60}ms` }}
+						>
+							<div className="flex items-center gap-3 pl-3">
+								<span
+									className={cn(
+										'flex h-10 w-10 shrink-0 items-center justify-center',
+										'rounded-lg',
+										iconBgClass
+									)}
+								>
+									<Icon className={cn('h-5 w-5', iconColorClass)} aria-hidden="true" />
+								</span>
+
+								<div className="flex min-w-0 flex-col">
+									<span className="text-(--text-xs) font-medium uppercase tracking-wider text-(--text-muted)">
+										{kpi.label}
+									</span>
+									<Counter
+										value={value}
+										formatter={kpi.formatter}
+										className={cn(
+											'truncate text-xl',
+											'font-bold text-(--text-primary)',
+											'font-[family-name:var(--font-display)]'
+										)}
+									/>
+								</div>
+							</div>
+						</div>
+					);
+				})}
+			</div>
+
+			{isStale && (
+				<div
+					className="flex items-center gap-1.5"
+					role="status"
+					aria-label="Data is stale, recalculation needed"
+				>
+					<span
+						className="size-2 animate-pulse rounded-full bg-(--color-stale)"
+						aria-hidden="true"
+					/>
+					<span className="text-(--text-xs) font-medium text-(--color-stale)">
+						Stale — recalculate to refresh
+					</span>
+				</div>
+			)}
+		</>
+	);
+}

--- a/apps/web/src/components/staffing/staffing-status-strip.test.tsx
+++ b/apps/web/src/components/staffing/staffing-status-strip.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { StaffingStatusStrip } from './staffing-status-strip';
+
+vi.mock('../shared/stale-pill', () => ({
+	StalePill: ({ label }: { label: string }) => <span data-testid="stale-pill">{label}</span>,
+}));
+
+afterEach(() => {
+	cleanup();
+});
+
+describe('StaffingStatusStrip', () => {
+	const baseProps = {
+		lastCalculatedAt: '2026-03-15T10:30:00.000Z',
+		staleModules: [] as string[],
+		demandPeriod: 'Academic Year 2 (Sep 2026 — Jun 2027)',
+		enrollmentCalculatedAt: '2026-03-15T09:00:00.000Z',
+		enrollmentStale: false,
+		supplyCount: { existing: 35, new: 5, vacancies: 2 },
+		coverageSummary: { deficit: 0, uncovered: 0, balanced: 20 },
+	};
+
+	// AC-13: Calc timestamp section
+	it('shows calc timestamp when data has been calculated', () => {
+		render(<StaffingStatusStrip {...baseProps} />);
+
+		expect(screen.getByText(/Last calculated/)).toBeDefined();
+		// Should show formatted date
+		expect(screen.queryByText('Not yet calculated')).toBeNull();
+	});
+
+	it('shows "Not yet calculated" when lastCalculatedAt is null', () => {
+		render(<StaffingStatusStrip {...baseProps} lastCalculatedAt={null} />);
+
+		expect(screen.getByText('Not yet calculated')).toBeDefined();
+	});
+
+	// AC-13: Stale warning
+	it('shows stale warning when STAFFING in staleModules', () => {
+		render(<StaffingStatusStrip {...baseProps} staleModules={['STAFFING']} />);
+
+		// The section label "Stale:" is inside a child span
+		const staleLabel = screen.getByText('Stale:');
+		expect(staleLabel).toBeDefined();
+	});
+
+	it('hides stale warning when STAFFING not in staleModules', () => {
+		render(<StaffingStatusStrip {...baseProps} staleModules={[]} />);
+
+		// Should not show a stale warning section for staffing
+		const statusStrip = screen.getByRole('status');
+		expect(statusStrip).toBeDefined();
+		// No stale text should appear (unless it's downstream)
+	});
+
+	// AC-13: Demand period
+	it('shows demand period text', () => {
+		render(<StaffingStatusStrip {...baseProps} />);
+
+		expect(screen.getByText(/Academic Year 2/)).toBeDefined();
+	});
+
+	// AC-13: Source indicator with enrollment stale warning
+	it('shows source indicator based on enrollment calculation date', () => {
+		render(<StaffingStatusStrip {...baseProps} />);
+
+		expect(screen.getByText(/enrollment/i)).toBeDefined();
+	});
+
+	it('shows warning on source indicator when ENROLLMENT is stale', () => {
+		render(
+			<StaffingStatusStrip
+				{...baseProps}
+				enrollmentStale
+				staleModules={['ENROLLMENT', 'STAFFING']}
+			/>
+		);
+
+		// Should have a warning-severity section for enrollment
+		const container = screen.getByRole('status');
+		expect(container).toBeDefined();
+	});
+
+	// AC-13: Supply count
+	it('shows supply count with existing, new, and vacancies breakdown', () => {
+		render(<StaffingStatusStrip {...baseProps} />);
+
+		// Should show employee counts: existing + new = 40 employees
+		expect(screen.getByText(/40 employees/i)).toBeDefined();
+	});
+
+	// AC-13: Coverage summary
+	it('shows coverage summary', () => {
+		render(<StaffingStatusStrip {...baseProps} />);
+
+		expect(screen.getByText(/coverage/i)).toBeDefined();
+	});
+
+	it('shows warning on coverage when deficit or uncovered exist', () => {
+		render(
+			<StaffingStatusStrip
+				{...baseProps}
+				coverageSummary={{ deficit: 3, uncovered: 1, balanced: 16 }}
+			/>
+		);
+
+		// Should contain deficit/uncovered information
+		expect(screen.getByText(/deficit/i)).toBeDefined();
+	});
+
+	// AC-13: StalePill badges for downstream modules
+	it('shows StalePill badges for downstream stale modules like PNL', () => {
+		render(<StaffingStatusStrip {...baseProps} staleModules={['STAFFING', 'PNL']} />);
+
+		const pills = screen.getAllByTestId('stale-pill');
+		expect(pills.length).toBeGreaterThan(0);
+		expect(screen.getByText('P&L')).toBeDefined();
+	});
+
+	// AC-13: Uses WorkspaceStatusStrip
+	it('renders using WorkspaceStatusStrip component', () => {
+		const { container } = render(<StaffingStatusStrip {...baseProps} />);
+
+		// WorkspaceStatusStrip renders a role="status" div
+		const statusStrip = container.querySelector('[role="status"]');
+		expect(statusStrip).not.toBeNull();
+	});
+
+	it('renders all 6 status sections', () => {
+		render(<StaffingStatusStrip {...baseProps} staleModules={['STAFFING', 'PNL']} />);
+
+		const statusStrip = screen.getByRole('status');
+		expect(statusStrip).toBeDefined();
+		// At minimum, should have multiple info sections
+		const sections = statusStrip.querySelectorAll('span');
+		expect(sections.length).toBeGreaterThanOrEqual(6);
+	});
+});

--- a/apps/web/src/components/staffing/staffing-status-strip.tsx
+++ b/apps/web/src/components/staffing/staffing-status-strip.tsx
@@ -1,0 +1,147 @@
+import { StalePill } from '../shared/stale-pill';
+import { WorkspaceStatusStrip } from '../shared/workspace-status-strip';
+import type { StatusSection } from '../shared/workspace-status-strip';
+
+const STALE_MODULE_LABELS: Record<string, string> = {
+	ENROLLMENT: 'Enrollment',
+	REVENUE: 'Revenue',
+	DHG: 'DHG',
+	STAFFING: 'Staffing',
+	PNL: 'P&L',
+};
+
+function formatTimestamp(value: string | null | undefined): string {
+	if (!value) {
+		return 'Not yet calculated';
+	}
+
+	return new Intl.DateTimeFormat('en-GB', {
+		timeZone: 'Asia/Riyadh',
+		dateStyle: 'medium',
+		timeStyle: 'short',
+	}).format(new Date(value));
+}
+
+export type StaffingStatusStripProps = {
+	lastCalculatedAt: string | null;
+	staleModules: string[];
+	demandPeriod: string;
+	enrollmentCalculatedAt: string | null;
+	enrollmentStale: boolean;
+	supplyCount: { existing: number; new: number; vacancies: number };
+	coverageSummary: { deficit: number; uncovered: number; balanced: number };
+};
+
+export function StaffingStatusStrip({
+	lastCalculatedAt,
+	staleModules,
+	demandPeriod,
+	enrollmentCalculatedAt,
+	enrollmentStale,
+	supplyCount,
+	coverageSummary,
+}: StaffingStatusStripProps) {
+	const isStaffingStale = staleModules.includes('STAFFING');
+	const downstreamStale = staleModules.filter((m) => m !== 'STAFFING' && m !== 'ENROLLMENT');
+
+	const totalEmployees = supplyCount.existing + supplyCount.new;
+	const hasDeficitOrUncovered = coverageSummary.deficit > 0 || coverageSummary.uncovered > 0;
+
+	const sections: StatusSection[] = [];
+
+	// Section 1: Calc timestamp
+	sections.push({
+		key: 'lastCalculated',
+		label: 'Last calculated',
+		value: formatTimestamp(lastCalculatedAt),
+		severity: lastCalculatedAt ? 'default' : 'warning',
+		priority: 0,
+	});
+
+	// Section 2: Stale warning
+	if (isStaffingStale) {
+		sections.push({
+			key: 'stale',
+			label: 'Stale',
+			value: 'Staffing data is stale — recalculate',
+			severity: 'warning',
+			badge: true,
+			priority: 1,
+		});
+	}
+
+	// Section 3: Demand period
+	sections.push({
+		key: 'demandPeriod',
+		label: 'Demand',
+		value: demandPeriod,
+		priority: 2,
+	});
+
+	// Section 4: Source indicator
+	const enrollmentInfo = enrollmentCalculatedAt
+		? `Based on enrollment AY2 headcounts (calculated ${formatTimestamp(enrollmentCalculatedAt)})`
+		: 'Based on enrollment AY2 headcounts';
+
+	sections.push({
+		key: 'source',
+		label: 'Source',
+		value: enrollmentInfo,
+		severity: enrollmentStale ? 'warning' : 'default',
+		priority: 3,
+	});
+
+	// Section 5: Supply count
+	sections.push({
+		key: 'supply',
+		label: 'Supply',
+		value: `${totalEmployees} employees (${supplyCount.existing} existing, ${supplyCount.new} new) + ${supplyCount.vacancies} ${supplyCount.vacancies === 1 ? 'vacancy' : 'vacancies'}`,
+		priority: 4,
+	});
+
+	// Section 6: Coverage summary
+	if (hasDeficitOrUncovered) {
+		const parts: string[] = [];
+		if (coverageSummary.deficit > 0) {
+			parts.push(`${coverageSummary.deficit} deficit`);
+		}
+		if (coverageSummary.uncovered > 0) {
+			parts.push(`${coverageSummary.uncovered} uncovered`);
+		}
+		parts.push(`${coverageSummary.balanced} balanced`);
+
+		sections.push({
+			key: 'coverage',
+			label: 'Coverage',
+			value: parts.join(', '),
+			severity: 'warning',
+			priority: 5,
+		});
+	} else {
+		sections.push({
+			key: 'coverage',
+			label: 'Coverage',
+			value: `${coverageSummary.balanced} balanced`,
+			severity: 'success',
+			priority: 5,
+		});
+	}
+
+	// Downstream stale pills
+	if (downstreamStale.length > 0) {
+		sections.push({
+			key: 'downstream',
+			label: 'Downstream stale',
+			value: (
+				<span className="flex items-center gap-1.5">
+					{downstreamStale.map((mod) => (
+						<StalePill key={mod} label={STALE_MODULE_LABELS[mod] ?? mod} />
+					))}
+				</span>
+			),
+			priority: 6,
+		});
+	}
+
+	return <WorkspaceStatusStrip sections={sections} />;
+}


### PR DESCRIPTION
## Summary

- Add `StaffingKpiRibbonV2` with 6 KPI metrics (Total Headcount, FTE Gap, Staff Cost, HSA Budget, H/E Ratio, Recharge Cost) with Counter animations, dynamic FTE gap border colors, stale indicator, and responsive grid layout
- Add `StaffingStatusStrip` using WorkspaceStatusStrip with 6 sections (calc timestamp, stale warning, demand period, enrollment source, supply count, coverage summary) and StalePill badges for downstream modules
- Add `StaffingInspectorContent` with 3 views registered via `registerPanelContent('staffing')`: default overview, requirement line detail, and support employee detail
- Add `StaffingGuideContent` contextual help registered via `registerGuideContent('staffing')`

## Test plan

- [x] 52 new tests covering AC-12, AC-13, AC-14
- [x] All 514 web tests pass (46 test files)
- [x] All 1217 API tests pass (90 test files)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (zero errors, zero warnings)

Fixes #230
Part of Epic #221

Generated with [Claude Code](https://claude.com/claude-code)